### PR TITLE
Fix Shadows behaviour (again)

### DIFF
--- a/MaterialSkin/Controls/MaterialFloatingActionButton.cs
+++ b/MaterialSkin/Controls/MaterialFloatingActionButton.cs
@@ -91,7 +91,36 @@
         protected override void OnParentChanged(EventArgs e)
         {
             base.OnParentChanged(e);
-            if (DrawShadows && Parent != null) Parent.Paint += drawShadowOnParent;
+            if (DrawShadows && Parent != null) AddShadowPaintEvent(Parent, drawShadowOnParent);
+            if (_oldParent != null) RemoveShadowPaintEvent(_oldParent, drawShadowOnParent);
+            _oldParent = Parent;
+        }
+        Control _oldParent;
+
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+            if (Parent == null) return;
+            if (Visible)
+                AddShadowPaintEvent(Parent, drawShadowOnParent);
+            else
+                RemoveShadowPaintEvent(Parent, drawShadowOnParent);
+        }
+
+        bool _shadowDrawEventSubscribed = false;
+        private void AddShadowPaintEvent(Control control, PaintEventHandler shadowPaintEvent)
+        {
+            if (_shadowDrawEventSubscribed) return;
+            control.Paint += shadowPaintEvent;
+            control.Invalidate();
+            _shadowDrawEventSubscribed = true;
+        }
+        private void RemoveShadowPaintEvent(Control control, PaintEventHandler shadowPaintEvent)
+        {
+            if (!_shadowDrawEventSubscribed) return;
+            control.Paint -= shadowPaintEvent;
+            control.Invalidate();
+            _shadowDrawEventSubscribed = false;
         }
 
         private void setSize(bool mini)
@@ -116,8 +145,7 @@
         {
             if (Parent == null)
             {
-                ((Control)sender).Paint -= drawShadowOnParent;
-                ((Control)sender).Invalidate();
+                RemoveShadowPaintEvent((Control)sender, drawShadowOnParent);
                 return;
             }
 


### PR DESCRIPTION
Fixes #46 
- Fixes shadows not hidding when component visibility is set to false
- Fixes shadows leaving a "ghost" on previous parent
- Added lock to shadow event, this should guarantee that only one shadow paint instance exists

**NOTE:** This may be breaking the form when in design mode, if you experience this, the solution for now is to click on "ignore and continue"