### PR TITLE
Fix Combobox

### DIFF
--- a/MaterialSkin/Controls/MaterialComboBox.cs
+++ b/MaterialSkin/Controls/MaterialComboBox.cs
@@ -261,11 +261,21 @@
             {
                 g.FillRectangle(SkinManager.BackgroundHoverBrush, e.Bounds);
             }
+            
+            string Text = "";
+            if (!string.IsNullOrWhiteSpace(DisplayMember))
+            {
+                Text = Items[e.Index].GetType().GetProperty(DisplayMember).GetValue(Items[e.Index], null).ToString();
+            }
+            else
+            {
+                Text = Items[e.Index].ToString();
+            }
 
             using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
             {
                 NativeText.DrawTransparentText(
-                Items[e.Index].ToString(),
+                Text,
                 SkinManager.getFontByType(MaterialSkinManager.fontType.Subtitle1),
                 SkinManager.TextHighEmphasisColor,
                 new Point(e.Bounds.Location.X + SkinManager.FORM_PADDING, e.Bounds.Location.Y),


### PR DESCRIPTION
With this change it will be possible to add a DataSource value of type Dictionary to this control.

For example:

Dictionary<int, string> Items = new Dictionary<int, string>();
                Items.Add(1, "Option 1");
                Items.Add(2, "Option 2");
                Items.Add(3, "Option 3");

                cboGroupArticle.DisplayMember = "Value";
                cboGroupArticle.ValueMember = "Key";
                cboGroupArticle.DataSource = new BindingSource(Items, null);