### PR TITLE
Added ability to create a custom theme

### DIFF
--- a/MaterialSkin/Controls/MaterialButton.cs
+++ b/MaterialSkin/Controls/MaterialButton.cs
@@ -312,7 +312,7 @@
                             SkinManager.ColorScheme.AccentColor.Lighten(0.5f) : // Emphasis with accent
                             SkinManager.ColorScheme.LightPrimaryColor) : // Emphasis
                             (UseAccentColor ? SkinManager.ColorScheme.AccentColor : // Normal with accent
-                            SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? SkinManager.ColorScheme.PrimaryColor : SkinManager.ColorScheme.LightPrimaryColor))))) // Normal
+                            SkinManager.Theme.RippleColor))))) // Normal
                     {
                         var rippleSize = (int)(animationValue * Width * 2);
                         g.FillEllipse(rippleBrush, new Rectangle(animationSource.X - rippleSize / 2, animationSource.Y - rippleSize / 2, rippleSize, rippleSize));

--- a/MaterialSkin/Controls/MaterialCheckBox.cs
+++ b/MaterialSkin/Controls/MaterialCheckBox.cs
@@ -133,7 +133,7 @@
                 int rippleSize = (int)(rippleHeight * (0.7 + (0.3 * animationValue)));
 
                 using (SolidBrush rippleBrush = new SolidBrush(Color.FromArgb((int)(40 * animationValue),
-                    !Checked ? (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? Color.Black : Color.White) : brush.Color))) // no animation
+                    !Checked ? SkinManager.Theme.SwitchRippleColor : brush.Color))) // no animation
                 {
                     g.FillEllipse(rippleBrush, new Rectangle(animationSource.X - rippleSize / 2, animationSource.Y - rippleSize / 2, rippleSize, rippleSize));
                 }
@@ -147,7 +147,7 @@
                     double animationValue = _rippleAM.GetProgress(i);
                     int rippleSize = (_rippleAM.GetDirection(i) == AnimationDirection.InOutIn) ? (int)(rippleHeight * (0.7 + (0.3 * animationValue))) : rippleHeight;
 
-                    using (SolidBrush rippleBrush = new SolidBrush(Color.FromArgb((int)((animationValue * 40)), !Checked ? (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? Color.Black : Color.White) : brush.Color)))
+                    using (SolidBrush rippleBrush = new SolidBrush(Color.FromArgb((int)((animationValue * 40)), !Checked ? SkinManager.Theme.SwitchRippleColor : brush.Color)))
                     {
                         g.FillEllipse(rippleBrush, new Rectangle(animationSource.X - rippleSize / 2, animationSource.Y - rippleSize / 2, rippleSize, rippleSize));
                     }

--- a/MaterialSkin/Controls/MaterialDrawer.cs
+++ b/MaterialSkin/Controls/MaterialDrawer.cs
@@ -189,7 +189,7 @@
                 return;
 
             // Calculate lightness and color
-            float l = UseColors ? SkinManager.ColorScheme.TextColor.R / 255 : SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? 0f : 1f;
+            float l = UseColors ? SkinManager.ColorScheme.TextColor.R / 255 : SkinManager.Theme.DrawerLightness;
             float r = (_highlightWithAccent ? SkinManager.ColorScheme.AccentColor.R : SkinManager.ColorScheme.PrimaryColor.R) / 255f;
             float g = (_highlightWithAccent ? SkinManager.ColorScheme.AccentColor.G : SkinManager.ColorScheme.PrimaryColor.G) / 255f;
             float b = (_highlightWithAccent ? SkinManager.ColorScheme.AccentColor.B : SkinManager.ColorScheme.PrimaryColor.B) / 255f;
@@ -440,8 +440,7 @@
             {
                 var rippleBrush = new SolidBrush(Color.FromArgb((int)(70 - (clickAnimProgress * 70)),
                     UseColors ? SkinManager.ColorScheme.AccentColor : // Using colors
-                    SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? SkinManager.ColorScheme.PrimaryColor : // light theme
-                    SkinManager.ColorScheme.LightPrimaryColor)); // dark theme
+                    SkinManager.Theme.RippleColor));
 
                 g.SetClip(_drawerItemPaths[_baseTabControl.SelectedIndex]);
                 g.FillEllipse(rippleBrush, new Rectangle(_animationSource.X + dx - (rSize / 2), _animationSource.Y - rSize / 2, rSize, rSize));
@@ -458,8 +457,7 @@
                 Brush bgBrush = new SolidBrush(Color.FromArgb(CalculateAlpha(60, 0, currentTabIndex, clickAnimProgress, 1 - showHideAnimProgress),
                     UseColors ? _backgroundWithAccent ? SkinManager.ColorScheme.AccentColor : SkinManager.ColorScheme.LightPrimaryColor : // using colors
                     _backgroundWithAccent ? SkinManager.ColorScheme.AccentColor : // defaul accent
-                    SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? SkinManager.ColorScheme.PrimaryColor : // default light
-                    SkinManager.ColorScheme.LightPrimaryColor)); // default dark
+					SkinManager.Theme.RippleColor)); // default dark
                 g.FillPath(bgBrush, _drawerItemPaths[currentTabIndex]);
                 bgBrush.Dispose();
 

--- a/MaterialSkin/Controls/MaterialRadioButton.cs
+++ b/MaterialSkin/Controls/MaterialRadioButton.cs
@@ -150,7 +150,7 @@
                 int rippleSize = (int)(rippleHeight * (0.7 + (0.3 * animationValue)));
 
                 using (SolidBrush rippleBrush = new SolidBrush(Color.FromArgb((int)(40 * animationValue),
-                    !Checked ? (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? Color.Black : Color.White) : RadioColor)))
+                    !Checked ? SkinManager.Theme.SwitchRippleColor : RadioColor)))
                 {
                     g.FillEllipse(rippleBrush, new Rectangle(animationSource.X - rippleSize / 2, animationSource.Y - rippleSize / 2, rippleSize - 1, rippleSize - 1));
                 }
@@ -164,7 +164,7 @@
                     double animationValue = _rippleAM.GetProgress(i);
                     int rippleSize = (_rippleAM.GetDirection(i) == AnimationDirection.InOutIn) ? (int)(rippleHeight * (0.7 + (0.3 * animationValue))) : rippleHeight;
 
-                    using (SolidBrush rippleBrush = new SolidBrush(Color.FromArgb((int)((animationValue * 40)), !Checked ? (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? Color.Black : Color.White) : RadioColor)))
+                    using (SolidBrush rippleBrush = new SolidBrush(Color.FromArgb((int)((animationValue * 40)), !Checked ? SkinManager.Theme.SwitchRippleColor : RadioColor)))
                     {
                         g.FillEllipse(rippleBrush, new Rectangle(animationSource.X - rippleSize / 2, animationSource.Y - rippleSize / 2, rippleSize - 1, rippleSize - 1));
                     }

--- a/MaterialSkin/Controls/MaterialSwitch.cs
+++ b/MaterialSkin/Controls/MaterialSwitch.cs
@@ -160,7 +160,7 @@
 
             Color rippleColor = Color.FromArgb(40, // color alpha
                 Checked ? SkinManager.ColorScheme.AccentColor : // On color
-                (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ? Color.Black : Color.White)); // Off color
+				SkinManager.Theme.SwitchRippleColor); // Off color
 
             if (Ripple && _rippleAM.IsAnimating())
             {

--- a/MaterialSkin/MaterialSkin.csproj
+++ b/MaterialSkin/MaterialSkin.csproj
@@ -119,6 +119,9 @@
       <AutoGen>True</AutoGen>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="Themes\Theme.cs" />
+    <Compile Include="Themes\ThemeDark.cs" />
+    <Compile Include="Themes\ThemeLight.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Controls\FlexibleMaterialDialog.resx">

--- a/MaterialSkin/MaterialSkinManager.cs
+++ b/MaterialSkin/MaterialSkinManager.cs
@@ -2,6 +2,7 @@
 {
     using MaterialSkin.Controls;
     using MaterialSkin.Properties;
+    using MaterialSkin.Themes;
     using System;
     using System.Collections.Generic;
     using System.Drawing;
@@ -34,7 +35,7 @@
         // Constructor
         private MaterialSkinManager()
         {
-            Theme = Themes.LIGHT;
+			Theme = new ThemeLight();
             ColorScheme = new ColorScheme(Primary.Indigo500, Primary.Indigo700, Primary.Indigo100, Accent.Pink200, TextShade.WHITE);
 
             // Create and cache Roboto fonts
@@ -89,9 +90,9 @@
         }
 
         // Themes
-        private Themes _theme;
+        private Theme _theme;
 
-        public Themes Theme
+        public Theme Theme
         {
             get { return _theme; }
             set
@@ -115,138 +116,55 @@
             }
         }
 
-        public enum Themes : byte
-        {
-            LIGHT,
-            DARK
-        }
-
-        // Text
-        private static readonly Color TEXT_HIGH_EMPHASIS_LIGHT = Color.FromArgb(222, 255, 255, 255); // Alpha 87%
-
-        private static readonly Brush TEXT_HIGH_EMPHASIS_LIGHT_BRUSH = new SolidBrush(TEXT_HIGH_EMPHASIS_LIGHT);
-        private static readonly Color TEXT_HIGH_EMPHASIS_DARK = Color.FromArgb(222, 0, 0, 0); // Alpha 87%
-        private static readonly Brush TEXT_HIGH_EMPHASIS_DARK_BRUSH = new SolidBrush(TEXT_HIGH_EMPHASIS_DARK);
-
-        private static readonly Color TEXT_MEDIUM_EMPHASIS_LIGHT = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
-        private static readonly Brush TEXT_MEDIUM_EMPHASIS_LIGHT_BRUSH = new SolidBrush(TEXT_MEDIUM_EMPHASIS_LIGHT);
-        private static readonly Color TEXT_MEDIUM_EMPHASIS_DARK = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
-        private static readonly Brush TEXT_MEDIUM_EMPHASIS_DARK_BRUSH = new SolidBrush(TEXT_MEDIUM_EMPHASIS_DARK);
-
-        private static readonly Color TEXT_DISABLED_OR_HINT_LIGHT = Color.FromArgb(97, 255, 255, 255); // Alpha 38%
-        private static readonly Brush TEXT_DISABLED_OR_HINT_LIGHT_BRUSH = new SolidBrush(TEXT_DISABLED_OR_HINT_LIGHT);
-        private static readonly Color TEXT_DISABLED_OR_HINT_DARK = Color.FromArgb(97, 0, 0, 0); // Alpha 38%
-        private static readonly Brush TEXT_DISABLED_OR_HINT_DARK_BRUSH = new SolidBrush(TEXT_DISABLED_OR_HINT_DARK);
-
-        // Dividers and thin lines
-        private static readonly Color DIVIDERS_LIGHT = Color.FromArgb(30, 255, 255, 255); // Alpha 30%
-
-        private static readonly Brush DIVIDERS_LIGHT_BRUSH = new SolidBrush(DIVIDERS_LIGHT);
-        private static readonly Color DIVIDERS_DARK = Color.FromArgb(30, 0, 0, 0); // Alpha 30%
-        private static readonly Brush DIVIDERS_DARK_BRUSH = new SolidBrush(DIVIDERS_DARK);
-        private static readonly Color DIVIDERS_ALTERNATIVE_LIGHT = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
-        private static readonly Brush DIVIDERS_ALTERNATIVE_LIGHT_BRUSH = new SolidBrush(DIVIDERS_ALTERNATIVE_LIGHT);
-        private static readonly Color DIVIDERS_ALTERNATIVE_DARK = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
-        private static readonly Brush DIVIDERS_ALTERNATIVE_DARK_BRUSH = new SolidBrush(DIVIDERS_ALTERNATIVE_DARK);
-
-        // Checkbox / Radio / Switches
-        private static readonly Color CHECKBOX_OFF_LIGHT = Color.FromArgb(138, 0, 0, 0);
-
-        private static readonly Brush CHECKBOX_OFF_LIGHT_BRUSH = new SolidBrush(CHECKBOX_OFF_LIGHT);
-        private static readonly Color CHECKBOX_OFF_DARK = Color.FromArgb(179, 255, 255, 255);
-        private static readonly Brush CHECKBOX_OFF_DARK_BRUSH = new SolidBrush(CHECKBOX_OFF_DARK);
-        private static readonly Color CHECKBOX_OFF_DISABLED_LIGHT = Color.FromArgb(66, 0, 0, 0);
-        private static readonly Brush CHECKBOX_OFF_DISABLED_LIGHT_BRUSH = new SolidBrush(CHECKBOX_OFF_DISABLED_LIGHT);
-        private static readonly Color CHECKBOX_OFF_DISABLED_DARK = Color.FromArgb(77, 255, 255, 255);
-        private static readonly Brush CHECKBOX_OFF_DISABLED_DARK_BRUSH = new SolidBrush(CHECKBOX_OFF_DISABLED_DARK);
-
-        // Switch specific
-        private static readonly Color SWITCH_OFF_THUMB_LIGHT = Color.FromArgb(255, 255, 255, 255);
-
-        private static readonly Color SWITCH_OFF_THUMB_DARK = Color.FromArgb(255, 190, 190, 190);
-        private static readonly Color SWITCH_OFF_TRACK_LIGHT = Color.FromArgb(100, 0, 0, 0);
-        private static readonly Color SWITCH_OFF_TRACK_DARK = Color.FromArgb(100, 255, 255, 255);
-        private static readonly Color SWITCH_OFF_DISABLED_THUMB_LIGHT = Color.FromArgb(255, 230, 230, 230);
-        private static readonly Color SWITCH_OFF_DISABLED_THUMB_DARK = Color.FromArgb(255, 150, 150, 150);
-
-        // Generic back colors - for user controls
-        private static readonly Color BACKGROUND_LIGHT = Color.FromArgb(255, 255, 255, 255);
-
-        private static readonly Brush BACKGROUND_LIGHT_BRUSH = new SolidBrush(BACKGROUND_LIGHT);
-        private static readonly Color BACKGROUND_DARK = Color.FromArgb(255, 80, 80, 80);
-        private static readonly Brush BACKGROUND_DARK_BRUSH = new SolidBrush(BACKGROUND_DARK);
-        private static readonly Color BACKGROUND_ALTERNATIVE_LIGHT = Color.FromArgb(10, 0, 0, 0);
-        private static readonly Brush BACKGROUND_ALTERNATIVE_LIGHT_BRUSH = new SolidBrush(BACKGROUND_ALTERNATIVE_LIGHT);
-        private static readonly Color BACKGROUND_ALTERNATIVE_DARK = Color.FromArgb(10, 255, 255, 255);
-        private static readonly Brush BACKGROUND_ALTERNATIVE_DARK_BRUSH = new SolidBrush(BACKGROUND_ALTERNATIVE_DARK);
-        private static readonly Color BACKGROUND_HOVER_LIGHT = Color.FromArgb(20, 0, 0, 0);
-        private static readonly Brush BACKGROUND_HOVER_LIGHT_BRUSH = new SolidBrush(BACKGROUND_HOVER_LIGHT);
-        private static readonly Color BACKGROUND_HOVER_DARK = Color.FromArgb(20, 255, 255, 255);
-        private static readonly Brush BACKGROUND_HOVER_DARK_BRUSH = new SolidBrush(BACKGROUND_HOVER_DARK);
-        private static readonly Color BACKGROUND_FOCUS_LIGHT = Color.FromArgb(30, 0, 0, 0);
-        private static readonly Brush BACKGROUND_FOCUS_LIGHT_BRUSH = new SolidBrush(BACKGROUND_FOCUS_LIGHT);
-        private static readonly Color BACKGROUND_FOCUS_DARK = Color.FromArgb(30, 255, 255, 255);
-        private static readonly Brush BACKGROUND_FOCUS_DARK_BRUSH = new SolidBrush(BACKGROUND_FOCUS_DARK);
-        private static readonly Color BACKGROUND_DISABLED_LIGHT = Color.FromArgb(25, 0, 0, 0);
-        private static readonly Brush BACKGROUND_DISABLED_LIGHT_BRUSH = new SolidBrush(BACKGROUND_DISABLED_LIGHT);
-        private static readonly Color BACKGROUND_DISABLED_DARK = Color.FromArgb(25, 255, 255, 255);
-        private static readonly Brush BACKGROUND_DISABLED_DARK_BRUSH = new SolidBrush(BACKGROUND_DISABLED_DARK);
-
-        // Backdrop colors - for containers, like forms or panels
-        private static readonly Color BACKDROP_LIGHT = Color.FromArgb(255, 242, 242, 242);
-
-        private static readonly Brush BACKDROP_LIGHT_BRUSH = new SolidBrush(BACKGROUND_LIGHT);
-        private static readonly Color BACKDROP_DARK = Color.FromArgb(255, 50, 50, 50);
-        private static readonly Brush BACKDROP_DARK_BRUSH = new SolidBrush(BACKGROUND_DARK);
 
         // Getters - Using these makes handling the dark theme switching easier
         // Text
-        public Color TextHighEmphasisColor => Theme == Themes.LIGHT ? TEXT_HIGH_EMPHASIS_DARK : TEXT_HIGH_EMPHASIS_LIGHT;
+        public Color TextHighEmphasisColor => Theme.TextHighEmphasisColor;
 
-        public Brush TextHighEmphasisBrush => Theme == Themes.LIGHT ? TEXT_HIGH_EMPHASIS_DARK_BRUSH : TEXT_HIGH_EMPHASIS_LIGHT_BRUSH;
-        public Color TextMediumEmphasisColor => Theme == Themes.LIGHT ? TEXT_MEDIUM_EMPHASIS_DARK : TEXT_MEDIUM_EMPHASIS_LIGHT;
-        public Brush TextMediumEmphasisBrush => Theme == Themes.LIGHT ? TEXT_MEDIUM_EMPHASIS_DARK_BRUSH : TEXT_MEDIUM_EMPHASIS_LIGHT_BRUSH;
-        public Color TextDisabledOrHintColor => Theme == Themes.LIGHT ? TEXT_DISABLED_OR_HINT_DARK : TEXT_DISABLED_OR_HINT_LIGHT;
-        public Brush TextDisabledOrHintBrush => Theme == Themes.LIGHT ? TEXT_DISABLED_OR_HINT_DARK_BRUSH : TEXT_DISABLED_OR_HINT_LIGHT_BRUSH;
+        public Brush TextHighEmphasisBrush => Theme.TextHighEmphasisBrush;
+        public Color TextMediumEmphasisColor => Theme.TextMediumEmphasisColor;
+        public Brush TextMediumEmphasisBrush => Theme.TextMediumEmphasisBrush;
+        public Color TextDisabledOrHintColor => Theme.TextDisabledOrHintColor;
+        public Brush TextDisabledOrHintBrush => Theme.TextDisabledOrHintBrush;
 
         // Divider
-        public Color DividersColor => Theme == Themes.LIGHT ? DIVIDERS_DARK : DIVIDERS_LIGHT;
+        public Color DividersColor => Theme.DividersColor;
 
-        public Brush DividersBrush => Theme == Themes.LIGHT ? DIVIDERS_DARK_BRUSH : DIVIDERS_LIGHT_BRUSH;
-        public Color DividersAlternativeColor => Theme == Themes.LIGHT ? DIVIDERS_ALTERNATIVE_DARK : DIVIDERS_ALTERNATIVE_LIGHT;
-        public Brush DividersAlternativeBrush => Theme == Themes.LIGHT ? DIVIDERS_ALTERNATIVE_DARK_BRUSH : DIVIDERS_ALTERNATIVE_LIGHT_BRUSH;
+        public Brush DividersBrush => Theme.DividersBrush;
+        public Color DividersAlternativeColor => Theme.DividersAlternativeColor;
+        public Brush DividersAlternativeBrush => Theme.DividersAlternativeBrush;
 
         // Checkbox / Radio / Switch
-        public Color CheckboxOffColor => Theme == Themes.LIGHT ? CHECKBOX_OFF_LIGHT : CHECKBOX_OFF_DARK;
+        public Color CheckboxOffColor => Theme.CheckboxOffColor;
 
-        public Brush CheckboxOffBrush => Theme == Themes.LIGHT ? CHECKBOX_OFF_LIGHT_BRUSH : CHECKBOX_OFF_DARK_BRUSH;
-        public Color CheckBoxOffDisabledColor => Theme == Themes.LIGHT ? CHECKBOX_OFF_DISABLED_LIGHT : CHECKBOX_OFF_DISABLED_DARK;
-        public Brush CheckBoxOffDisabledBrush => Theme == Themes.LIGHT ? CHECKBOX_OFF_DISABLED_LIGHT_BRUSH : CHECKBOX_OFF_DISABLED_DARK_BRUSH;
+        public Brush CheckboxOffBrush => Theme.CheckboxOffBrush;
+        public Color CheckBoxOffDisabledColor => Theme.CheckBoxOffDisabledColor;
+        public Brush CheckBoxOffDisabledBrush => Theme.CheckBoxOffDisabledBrush;
 
         // Switch
-        public Color SwitchOffColor => Theme == Themes.LIGHT ? CHECKBOX_OFF_DARK : CHECKBOX_OFF_LIGHT;
+        public Color SwitchOffColor => Theme.SwitchOffColor;
 
-        public Color SwitchOffThumbColor => Theme == Themes.LIGHT ? SWITCH_OFF_THUMB_LIGHT : SWITCH_OFF_THUMB_DARK;
-        public Color SwitchOffTrackColor => Theme == Themes.LIGHT ? SWITCH_OFF_TRACK_LIGHT : SWITCH_OFF_TRACK_DARK;
-        public Color SwitchOffDisabledThumbColor => Theme == Themes.LIGHT ? SWITCH_OFF_DISABLED_THUMB_LIGHT : SWITCH_OFF_DISABLED_THUMB_DARK;
+        public Color SwitchOffThumbColor => Theme.SwitchOffThumbColor;
+        public Color SwitchOffTrackColor => Theme.SwitchOffTrackColor;
+        public Color SwitchOffDisabledThumbColor => Theme.SwitchOffDisabledThumbColor;
 
         // Control Back colors
-        public Color BackgroundColor => Theme == Themes.LIGHT ? BACKGROUND_LIGHT : BACKGROUND_DARK;
+        public Color BackgroundColor => Theme.BackgroundColor;
 
-        public Brush BackgroundBrush => Theme == Themes.LIGHT ? BACKGROUND_LIGHT_BRUSH : BACKGROUND_DARK_BRUSH;
-        public Color BackgroundAlternativeColor => Theme == Themes.LIGHT ? BACKGROUND_ALTERNATIVE_LIGHT : BACKGROUND_ALTERNATIVE_DARK;
-        public Brush BackgroundAlternativeBrush => Theme == Themes.LIGHT ? BACKGROUND_ALTERNATIVE_LIGHT_BRUSH : BACKGROUND_ALTERNATIVE_DARK_BRUSH;
-        public Color BackgroundDisabledColor => Theme == Themes.LIGHT ? BACKGROUND_DISABLED_LIGHT : BACKGROUND_DISABLED_DARK;
-        public Brush BackgroundDisabledBrush => Theme == Themes.LIGHT ? BACKGROUND_DISABLED_LIGHT_BRUSH : BACKGROUND_DISABLED_DARK_BRUSH;
-        public Color BackgroundHoverColor => Theme == Themes.LIGHT ? BACKGROUND_HOVER_LIGHT : BACKGROUND_HOVER_DARK;
-        public Brush BackgroundHoverBrush => Theme == Themes.LIGHT ? BACKGROUND_HOVER_LIGHT_BRUSH : BACKGROUND_HOVER_DARK_BRUSH;
-        public Color BackgroundFocusColor => Theme == Themes.LIGHT ? BACKGROUND_FOCUS_LIGHT : BACKGROUND_FOCUS_DARK;
-        public Brush BackgroundFocusBrush => Theme == Themes.LIGHT ? BACKGROUND_FOCUS_LIGHT_BRUSH : BACKGROUND_FOCUS_DARK_BRUSH;
+        public Brush BackgroundBrush => Theme.BackgroundBrush;
+        public Color BackgroundAlternativeColor => Theme.BackgroundAlternativeColor;
+        public Brush BackgroundAlternativeBrush => Theme.BackgroundAlternativeBrush;
+        public Color BackgroundDisabledColor => Theme.BackgroundDisabledColor;
+        public Brush BackgroundDisabledBrush => Theme.BackgroundDisabledBrush;
+        public Color BackgroundHoverColor => Theme.BackgroundHoverColor;
+        public Brush BackgroundHoverBrush => Theme.BackgroundHoverBrush;
+        public Color BackgroundFocusColor => Theme.BackgroundFocusColor;
+        public Brush BackgroundFocusBrush => Theme.BackgroundFocusBrush;
 
         // Backdrop color
-        public Color BackdropColor => Theme == Themes.LIGHT ? BACKDROP_LIGHT : BACKDROP_DARK;
+        public Color BackdropColor => Theme.BackdropColor;
 
-        public Brush BackdropBrush => Theme == Themes.LIGHT ? BACKDROP_LIGHT_BRUSH : BACKDROP_DARK_BRUSH;
+        public Brush BackdropBrush => Theme.BackdropBrush;
 
         // Font Handling
         public enum fontType

--- a/MaterialSkin/MaterialSkinManager.cs
+++ b/MaterialSkin/MaterialSkinManager.cs
@@ -35,7 +35,7 @@
         // Constructor
         private MaterialSkinManager()
         {
-			Theme = new ThemeLight();
+			Theme = new ThemeLight(this);
             ColorScheme = new ColorScheme(Primary.Indigo500, Primary.Indigo700, Primary.Indigo100, Accent.Pink200, TextShade.WHITE);
 
             // Create and cache Roboto fonts

--- a/MaterialSkin/MaterialSkinManager.cs
+++ b/MaterialSkin/MaterialSkinManager.cs
@@ -103,6 +103,40 @@
             }
         }
 
+		private Theme _themeLight, _themeDark;
+		private bool _enabledLight;
+
+		public bool EnabledLightTheme { get => _enabledLight; }
+
+		public void SetThemes(Theme themeLight, Theme themeDark, bool defaultLight) {
+			_themeLight = themeLight;
+			_themeDark = themeDark;
+			_enabledLight = defaultLight;
+			Theme = _enabledLight ? _themeLight : _themeDark;
+		}
+
+		public enum ThemeSelector {
+			Opposite,
+			Light,
+			Dark
+		}
+
+		public void SwitchTheme(ThemeSelector selector) {
+			switch (selector) {
+				case ThemeSelector.Light:
+					_enabledLight = true;
+					break;
+				case ThemeSelector.Dark:
+					_enabledLight = false;
+					break;
+				case ThemeSelector.Opposite:
+					_enabledLight = !_enabledLight;
+					break;
+			}
+			Theme = _enabledLight ? _themeLight : _themeDark;
+		}
+
+
         private ColorScheme _colorScheme;
 
         public ColorScheme ColorScheme

--- a/MaterialSkin/Themes/Theme.cs
+++ b/MaterialSkin/Themes/Theme.cs
@@ -5,29 +5,83 @@ namespace MaterialSkin.Themes {
 	public class Theme {
 
 		// Text
-		public Color TextHighEmphasisColor { get; set; }
 
+		private Color textHighEmphasisColor;
+		public Color TextHighEmphasisColor {
+			get => textHighEmphasisColor;
+			set {
+				textHighEmphasisColor = value;
+				TextHighEmphasisBrush = new SolidBrush(value);
+			}
+		}
 		public Brush TextHighEmphasisBrush { get; set; }
-		public Color TextMediumEmphasisColor { get; set; }
+
+		private Color textMediumEmphasisColor;
+		public Color TextMediumEmphasisColor {
+			get => textMediumEmphasisColor;
+			set {
+				textMediumEmphasisColor = value;
+				TextMediumEmphasisBrush = new SolidBrush(value);
+			}
+		}
 		public Brush TextMediumEmphasisBrush { get; set; }
-		public Color TextDisabledOrHintColor { get; set; }
+
+		private Color textDisabledOrHintColor;
+		public Color TextDisabledOrHintColor {
+			get => textDisabledOrHintColor;
+			set {
+				textDisabledOrHintColor = value;
+				TextDisabledOrHintBrush = new SolidBrush(value);
+			}
+		}
 		public Brush TextDisabledOrHintBrush { get; set; }
 
 		// Divider
-		public Color DividersColor { get; set; }
 
+		private Color dividersColor;
+		public Color DividersColor {
+			get => dividersColor;
+			set {
+				dividersColor = value;
+				DividersBrush = new SolidBrush(value);
+			}
+		}
 		public Brush DividersBrush { get; set; }
-		public Color DividersAlternativeColor { get; set; }
+
+		private Color dividersAlternativeColor;
+		public Color DividersAlternativeColor {
+			get => dividersAlternativeColor;
+			set {
+				dividersAlternativeColor = value;
+				DividersAlternativeBrush = new SolidBrush(value);
+			}
+		}
 		public Brush DividersAlternativeBrush { get; set; }
 
 		// Checkbox / Radio / Switch
-		public Color CheckboxOffColor { get; set; }
 
+		private Color checkboxOffColor;
+		public Color CheckboxOffColor {
+			get => checkboxOffColor;
+			set {
+				checkboxOffColor = value;
+				CheckboxOffBrush = new SolidBrush(value);
+			}
+		}
 		public Brush CheckboxOffBrush { get; set; }
-		public Color CheckBoxOffDisabledColor { get; set; }
+
+		private Color checkBoxOffDisabledColor;
+		public Color CheckBoxOffDisabledColor {
+			get => checkBoxOffDisabledColor;
+			set {
+				checkBoxOffDisabledColor = value;
+				CheckBoxOffDisabledBrush = new SolidBrush(value);
+			}
+		}
 		public Brush CheckBoxOffDisabledBrush { get; set; }
 
 		// Switch
+
 		public Color SwitchOffColor { get; set; }
 
 		public Color SwitchOffThumbColor { get; set; }
@@ -35,21 +89,67 @@ namespace MaterialSkin.Themes {
 		public Color SwitchOffDisabledThumbColor { get; set; }
 
 		// Control Back colors
-		public Color BackgroundColor { get; set; }
 
+		private Color backgroundColor;
+		public Color BackgroundColor {
+			get => backgroundColor;
+			set {
+				backgroundColor = value;
+				BackgroundBrush = new SolidBrush(value);
+			}
+		}
 		public Brush BackgroundBrush { get; set; }
-		public Color BackgroundAlternativeColor { get; set; }
+
+		private Color backgroundAlternativeColor;
+		public Color BackgroundAlternativeColor {
+			get => backgroundAlternativeColor;
+			set {
+				backgroundAlternativeColor = value;
+				BackgroundAlternativeBrush = new SolidBrush(value);
+			}
+		}
 		public Brush BackgroundAlternativeBrush { get; set; }
-		public Color BackgroundDisabledColor { get; set; }
+
+		private Color backgroundDisabledColor;
+		public Color BackgroundDisabledColor {
+			get => backgroundDisabledColor;
+			set {
+				backgroundDisabledColor = value;
+				BackgroundDisabledBrush = new SolidBrush(value);
+			}
+		}
 		public Brush BackgroundDisabledBrush { get; set; }
-		public Color BackgroundHoverColor { get; set; }
+
+		private Color backgroundHoverColor;
+		public Color BackgroundHoverColor {
+			get => backgroundHoverColor;
+			set {
+				backgroundHoverColor = value;
+				BackgroundHoverBrush = new SolidBrush(value);
+			}
+		}
 		public Brush BackgroundHoverBrush { get; set; }
-		public Color BackgroundFocusColor { get; set; }
+
+		private Color backgroundFocusColor;
+		public Color BackgroundFocusColor {
+			get => backgroundFocusColor;
+			set {
+				backgroundFocusColor = value;
+				BackgroundFocusBrush = new SolidBrush(value);
+			}
+		}
 		public Brush BackgroundFocusBrush { get; set; }
 
 		// Backdrop color
-		public Color BackdropColor { get; set; }
 
+		private Color backdropColor;
+		public Color BackdropColor {
+			get => backdropColor;
+			set {
+				backdropColor = value;
+				BackdropBrush = new SolidBrush(value);
+			}
+		}
 		public Brush BackdropBrush { get; set; }
 
 	}

--- a/MaterialSkin/Themes/Theme.cs
+++ b/MaterialSkin/Themes/Theme.cs
@@ -152,5 +152,13 @@ namespace MaterialSkin.Themes {
 		}
 		public Brush BackdropBrush { get; set; }
 
+		// for controls
+
+		public virtual Color RippleColor { get; set; }
+
+		public Color SwitchRippleColor { get; set; }
+
+		public float DrawerLightness { get; set; }
+
 	}
 }

--- a/MaterialSkin/Themes/Theme.cs
+++ b/MaterialSkin/Themes/Theme.cs
@@ -1,0 +1,56 @@
+﻿using System.Drawing;
+
+namespace MaterialSkin.Themes {
+
+	public class Theme {
+
+		// Text
+		public Color TextHighEmphasisColor { get; set; }
+
+		public Brush TextHighEmphasisBrush { get; set; }
+		public Color TextMediumEmphasisColor { get; set; }
+		public Brush TextMediumEmphasisBrush { get; set; }
+		public Color TextDisabledOrHintColor { get; set; }
+		public Brush TextDisabledOrHintBrush { get; set; }
+
+		// Divider
+		public Color DividersColor { get; set; }
+
+		public Brush DividersBrush { get; set; }
+		public Color DividersAlternativeColor { get; set; }
+		public Brush DividersAlternativeBrush { get; set; }
+
+		// Checkbox / Radio / Switch
+		public Color CheckboxOffColor { get; set; }
+
+		public Brush CheckboxOffBrush { get; set; }
+		public Color CheckBoxOffDisabledColor { get; set; }
+		public Brush CheckBoxOffDisabledBrush { get; set; }
+
+		// Switch
+		public Color SwitchOffColor { get; set; }
+
+		public Color SwitchOffThumbColor { get; set; }
+		public Color SwitchOffTrackColor { get; set; }
+		public Color SwitchOffDisabledThumbColor { get; set; }
+
+		// Control Back colors
+		public Color BackgroundColor { get; set; }
+
+		public Brush BackgroundBrush { get; set; }
+		public Color BackgroundAlternativeColor { get; set; }
+		public Brush BackgroundAlternativeBrush { get; set; }
+		public Color BackgroundDisabledColor { get; set; }
+		public Brush BackgroundDisabledBrush { get; set; }
+		public Color BackgroundHoverColor { get; set; }
+		public Brush BackgroundHoverBrush { get; set; }
+		public Color BackgroundFocusColor { get; set; }
+		public Brush BackgroundFocusBrush { get; set; }
+
+		// Backdrop color
+		public Color BackdropColor { get; set; }
+
+		public Brush BackdropBrush { get; set; }
+
+	}
+}

--- a/MaterialSkin/Themes/ThemeDark.cs
+++ b/MaterialSkin/Themes/ThemeDark.cs
@@ -1,16 +1,18 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 namespace MaterialSkin.Themes {
 
 	public class ThemeDark : Theme {
 
-		public ThemeDark() {
+		private MaterialSkinManager skinManager;
+
+		public ThemeDark(MaterialSkinManager skinManager) {
+			this.skinManager = skinManager;
 
 			// Text
 			TextHighEmphasisColor = Color.FromArgb(222, 255, 255, 255); // Alpha 87%
-
 			TextMediumEmphasisColor = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
-
 			TextDisabledOrHintColor = Color.FromArgb(97, 255, 255, 255); // Alpha 38%
 
 			// Divider
@@ -38,6 +40,16 @@ namespace MaterialSkin.Themes {
 			// Backdrop colors - for containers, like forms or panels
 			BackdropColor = Color.FromArgb(255, 50, 50, 50);
 			BackdropBrush = new SolidBrush(BackgroundColor); // not a bug?
+
+			// for controls
+			SwitchRippleColor = Color.White;
+			DrawerLightness = 1f;
+		}
+
+
+		public override Color RippleColor {
+			get => skinManager.ColorScheme.LightPrimaryColor;
+			set => throw new InvalidOperationException();
 		}
 
 	}

--- a/MaterialSkin/Themes/ThemeDark.cs
+++ b/MaterialSkin/Themes/ThemeDark.cs
@@ -1,0 +1,107 @@
+﻿using System.Drawing;
+
+namespace MaterialSkin.Themes {
+
+	public class ThemeDark : Theme {
+
+		public ThemeDark() {
+
+			// Text
+			TextHighEmphasisColor = TEXT_HIGH_EMPHASIS_LIGHT;
+
+			TextHighEmphasisBrush = TEXT_HIGH_EMPHASIS_LIGHT_BRUSH;
+			TextMediumEmphasisColor = TEXT_MEDIUM_EMPHASIS_LIGHT;
+			TextMediumEmphasisBrush = TEXT_MEDIUM_EMPHASIS_LIGHT_BRUSH;
+			TextDisabledOrHintColor = TEXT_DISABLED_OR_HINT_LIGHT;
+			TextDisabledOrHintBrush = TEXT_DISABLED_OR_HINT_LIGHT_BRUSH;
+
+			// Divider
+			DividersColor = DIVIDERS_LIGHT;
+
+			DividersBrush = DIVIDERS_LIGHT_BRUSH;
+			DividersAlternativeColor = DIVIDERS_ALTERNATIVE_LIGHT;
+			DividersAlternativeBrush = DIVIDERS_ALTERNATIVE_LIGHT_BRUSH;
+
+			// Checkbox / Radio / Switch
+			CheckboxOffColor = CHECKBOX_OFF_DARK;
+
+			CheckboxOffBrush = CHECKBOX_OFF_DARK_BRUSH;
+			CheckBoxOffDisabledColor = CHECKBOX_OFF_DISABLED_DARK;
+			CheckBoxOffDisabledBrush = CHECKBOX_OFF_DISABLED_DARK_BRUSH;
+
+			// Switch
+			SwitchOffColor = CHECKBOX_OFF_LIGHT;
+
+			SwitchOffThumbColor = SWITCH_OFF_THUMB_DARK;
+			SwitchOffTrackColor = SWITCH_OFF_TRACK_DARK;
+			SwitchOffDisabledThumbColor = SWITCH_OFF_DISABLED_THUMB_DARK;
+
+			// Control Back colors
+			BackgroundColor = BACKGROUND_DARK;
+
+			BackgroundBrush = BACKGROUND_DARK_BRUSH;
+			BackgroundAlternativeColor = BACKGROUND_ALTERNATIVE_DARK;
+			BackgroundAlternativeBrush = BACKGROUND_ALTERNATIVE_DARK_BRUSH;
+			BackgroundDisabledColor = BACKGROUND_DISABLED_DARK;
+			BackgroundDisabledBrush = BACKGROUND_DISABLED_DARK_BRUSH;
+			BackgroundHoverColor = BACKGROUND_HOVER_DARK;
+			BackgroundHoverBrush = BACKGROUND_HOVER_DARK_BRUSH;
+			BackgroundFocusColor = BACKGROUND_FOCUS_DARK;
+			BackgroundFocusBrush = BACKGROUND_FOCUS_DARK_BRUSH;
+
+			// Backdrop color
+			BackdropColor = BACKDROP_DARK;
+
+			BackdropBrush = BACKDROP_DARK_BRUSH;
+		}
+
+
+		// Text
+		private static readonly Color TEXT_HIGH_EMPHASIS_LIGHT = Color.FromArgb(222, 255, 255, 255); // Alpha 87%
+
+		private static readonly Brush TEXT_HIGH_EMPHASIS_LIGHT_BRUSH = new SolidBrush(TEXT_HIGH_EMPHASIS_LIGHT);
+
+		private static readonly Color TEXT_MEDIUM_EMPHASIS_LIGHT = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
+		private static readonly Brush TEXT_MEDIUM_EMPHASIS_LIGHT_BRUSH = new SolidBrush(TEXT_MEDIUM_EMPHASIS_LIGHT);
+
+		private static readonly Color TEXT_DISABLED_OR_HINT_LIGHT = Color.FromArgb(97, 255, 255, 255); // Alpha 38%
+		private static readonly Brush TEXT_DISABLED_OR_HINT_LIGHT_BRUSH = new SolidBrush(TEXT_DISABLED_OR_HINT_LIGHT);
+
+		// Dividers and thin lines
+		private static readonly Color DIVIDERS_LIGHT = Color.FromArgb(30, 255, 255, 255); // Alpha 30%
+
+		private static readonly Brush DIVIDERS_LIGHT_BRUSH = new SolidBrush(DIVIDERS_LIGHT);
+		private static readonly Color DIVIDERS_ALTERNATIVE_LIGHT = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
+		private static readonly Brush DIVIDERS_ALTERNATIVE_LIGHT_BRUSH = new SolidBrush(DIVIDERS_ALTERNATIVE_LIGHT);
+
+		// Checkbox / Radio / Switches
+		private static readonly Color CHECKBOX_OFF_LIGHT = Color.FromArgb(138, 0, 0, 0);
+
+		private static readonly Color CHECKBOX_OFF_DARK = Color.FromArgb(179, 255, 255, 255);
+		private static readonly Brush CHECKBOX_OFF_DARK_BRUSH = new SolidBrush(CHECKBOX_OFF_DARK);
+		private static readonly Color CHECKBOX_OFF_DISABLED_DARK = Color.FromArgb(77, 255, 255, 255);
+		private static readonly Brush CHECKBOX_OFF_DISABLED_DARK_BRUSH = new SolidBrush(CHECKBOX_OFF_DISABLED_DARK);
+
+		// Switch specific
+		private static readonly Color SWITCH_OFF_THUMB_DARK = Color.FromArgb(255, 190, 190, 190);
+		private static readonly Color SWITCH_OFF_TRACK_DARK = Color.FromArgb(100, 255, 255, 255);
+		private static readonly Color SWITCH_OFF_DISABLED_THUMB_DARK = Color.FromArgb(255, 150, 150, 150);
+
+		// Generic back colors - for user controls
+		private static readonly Color BACKGROUND_DARK = Color.FromArgb(255, 80, 80, 80);
+		private static readonly Brush BACKGROUND_DARK_BRUSH = new SolidBrush(BACKGROUND_DARK);
+		private static readonly Color BACKGROUND_ALTERNATIVE_DARK = Color.FromArgb(10, 255, 255, 255);
+		private static readonly Brush BACKGROUND_ALTERNATIVE_DARK_BRUSH = new SolidBrush(BACKGROUND_ALTERNATIVE_DARK);
+		private static readonly Color BACKGROUND_HOVER_DARK = Color.FromArgb(20, 255, 255, 255);
+		private static readonly Brush BACKGROUND_HOVER_DARK_BRUSH = new SolidBrush(BACKGROUND_HOVER_DARK);
+		private static readonly Color BACKGROUND_FOCUS_DARK = Color.FromArgb(30, 255, 255, 255);
+		private static readonly Brush BACKGROUND_FOCUS_DARK_BRUSH = new SolidBrush(BACKGROUND_FOCUS_DARK);
+		private static readonly Color BACKGROUND_DISABLED_DARK = Color.FromArgb(25, 255, 255, 255);
+		private static readonly Brush BACKGROUND_DISABLED_DARK_BRUSH = new SolidBrush(BACKGROUND_DISABLED_DARK);
+
+		// Backdrop colors - for containers, like forms or panels
+		private static readonly Color BACKDROP_DARK = Color.FromArgb(255, 50, 50, 50);
+		private static readonly Brush BACKDROP_DARK_BRUSH = new SolidBrush(BACKGROUND_DARK);
+
+	}
+}

--- a/MaterialSkin/Themes/ThemeDark.cs
+++ b/MaterialSkin/Themes/ThemeDark.cs
@@ -7,101 +7,38 @@ namespace MaterialSkin.Themes {
 		public ThemeDark() {
 
 			// Text
-			TextHighEmphasisColor = TEXT_HIGH_EMPHASIS_LIGHT;
+			TextHighEmphasisColor = Color.FromArgb(222, 255, 255, 255); // Alpha 87%
 
-			TextHighEmphasisBrush = TEXT_HIGH_EMPHASIS_LIGHT_BRUSH;
-			TextMediumEmphasisColor = TEXT_MEDIUM_EMPHASIS_LIGHT;
-			TextMediumEmphasisBrush = TEXT_MEDIUM_EMPHASIS_LIGHT_BRUSH;
-			TextDisabledOrHintColor = TEXT_DISABLED_OR_HINT_LIGHT;
-			TextDisabledOrHintBrush = TEXT_DISABLED_OR_HINT_LIGHT_BRUSH;
+			TextMediumEmphasisColor = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
+
+			TextDisabledOrHintColor = Color.FromArgb(97, 255, 255, 255); // Alpha 38%
 
 			// Divider
-			DividersColor = DIVIDERS_LIGHT;
-
-			DividersBrush = DIVIDERS_LIGHT_BRUSH;
-			DividersAlternativeColor = DIVIDERS_ALTERNATIVE_LIGHT;
-			DividersAlternativeBrush = DIVIDERS_ALTERNATIVE_LIGHT_BRUSH;
+			DividersColor = Color.FromArgb(30, 255, 255, 255); // Alpha 30%
+			DividersAlternativeColor = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
 
 			// Checkbox / Radio / Switch
-			CheckboxOffColor = CHECKBOX_OFF_DARK;
-
-			CheckboxOffBrush = CHECKBOX_OFF_DARK_BRUSH;
-			CheckBoxOffDisabledColor = CHECKBOX_OFF_DISABLED_DARK;
-			CheckBoxOffDisabledBrush = CHECKBOX_OFF_DISABLED_DARK_BRUSH;
+			CheckboxOffColor = Color.FromArgb(179, 255, 255, 255);
+			CheckBoxOffDisabledColor = Color.FromArgb(77, 255, 255, 255);
 
 			// Switch
-			SwitchOffColor = CHECKBOX_OFF_LIGHT;
+			SwitchOffColor = Color.FromArgb(138, 0, 0, 0);
 
-			SwitchOffThumbColor = SWITCH_OFF_THUMB_DARK;
-			SwitchOffTrackColor = SWITCH_OFF_TRACK_DARK;
-			SwitchOffDisabledThumbColor = SWITCH_OFF_DISABLED_THUMB_DARK;
+			SwitchOffThumbColor = Color.FromArgb(255, 190, 190, 190);
+			SwitchOffTrackColor = Color.FromArgb(100, 255, 255, 255);
+			SwitchOffDisabledThumbColor = Color.FromArgb(255, 150, 150, 150);
 
 			// Control Back colors
-			BackgroundColor = BACKGROUND_DARK;
+			BackgroundColor = Color.FromArgb(255, 80, 80, 80);
+			BackgroundAlternativeColor = Color.FromArgb(10, 255, 255, 255);
+			BackgroundDisabledColor = Color.FromArgb(25, 255, 255, 255);
+			BackgroundHoverColor = Color.FromArgb(20, 255, 255, 255);
+			BackgroundFocusColor = Color.FromArgb(30, 255, 255, 255);
 
-			BackgroundBrush = BACKGROUND_DARK_BRUSH;
-			BackgroundAlternativeColor = BACKGROUND_ALTERNATIVE_DARK;
-			BackgroundAlternativeBrush = BACKGROUND_ALTERNATIVE_DARK_BRUSH;
-			BackgroundDisabledColor = BACKGROUND_DISABLED_DARK;
-			BackgroundDisabledBrush = BACKGROUND_DISABLED_DARK_BRUSH;
-			BackgroundHoverColor = BACKGROUND_HOVER_DARK;
-			BackgroundHoverBrush = BACKGROUND_HOVER_DARK_BRUSH;
-			BackgroundFocusColor = BACKGROUND_FOCUS_DARK;
-			BackgroundFocusBrush = BACKGROUND_FOCUS_DARK_BRUSH;
-
-			// Backdrop color
-			BackdropColor = BACKDROP_DARK;
-
-			BackdropBrush = BACKDROP_DARK_BRUSH;
+			// Backdrop colors - for containers, like forms or panels
+			BackdropColor = Color.FromArgb(255, 50, 50, 50);
+			BackdropBrush = new SolidBrush(BackgroundColor); // not a bug?
 		}
-
-
-		// Text
-		private static readonly Color TEXT_HIGH_EMPHASIS_LIGHT = Color.FromArgb(222, 255, 255, 255); // Alpha 87%
-
-		private static readonly Brush TEXT_HIGH_EMPHASIS_LIGHT_BRUSH = new SolidBrush(TEXT_HIGH_EMPHASIS_LIGHT);
-
-		private static readonly Color TEXT_MEDIUM_EMPHASIS_LIGHT = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
-		private static readonly Brush TEXT_MEDIUM_EMPHASIS_LIGHT_BRUSH = new SolidBrush(TEXT_MEDIUM_EMPHASIS_LIGHT);
-
-		private static readonly Color TEXT_DISABLED_OR_HINT_LIGHT = Color.FromArgb(97, 255, 255, 255); // Alpha 38%
-		private static readonly Brush TEXT_DISABLED_OR_HINT_LIGHT_BRUSH = new SolidBrush(TEXT_DISABLED_OR_HINT_LIGHT);
-
-		// Dividers and thin lines
-		private static readonly Color DIVIDERS_LIGHT = Color.FromArgb(30, 255, 255, 255); // Alpha 30%
-
-		private static readonly Brush DIVIDERS_LIGHT_BRUSH = new SolidBrush(DIVIDERS_LIGHT);
-		private static readonly Color DIVIDERS_ALTERNATIVE_LIGHT = Color.FromArgb(153, 255, 255, 255); // Alpha 60%
-		private static readonly Brush DIVIDERS_ALTERNATIVE_LIGHT_BRUSH = new SolidBrush(DIVIDERS_ALTERNATIVE_LIGHT);
-
-		// Checkbox / Radio / Switches
-		private static readonly Color CHECKBOX_OFF_LIGHT = Color.FromArgb(138, 0, 0, 0);
-
-		private static readonly Color CHECKBOX_OFF_DARK = Color.FromArgb(179, 255, 255, 255);
-		private static readonly Brush CHECKBOX_OFF_DARK_BRUSH = new SolidBrush(CHECKBOX_OFF_DARK);
-		private static readonly Color CHECKBOX_OFF_DISABLED_DARK = Color.FromArgb(77, 255, 255, 255);
-		private static readonly Brush CHECKBOX_OFF_DISABLED_DARK_BRUSH = new SolidBrush(CHECKBOX_OFF_DISABLED_DARK);
-
-		// Switch specific
-		private static readonly Color SWITCH_OFF_THUMB_DARK = Color.FromArgb(255, 190, 190, 190);
-		private static readonly Color SWITCH_OFF_TRACK_DARK = Color.FromArgb(100, 255, 255, 255);
-		private static readonly Color SWITCH_OFF_DISABLED_THUMB_DARK = Color.FromArgb(255, 150, 150, 150);
-
-		// Generic back colors - for user controls
-		private static readonly Color BACKGROUND_DARK = Color.FromArgb(255, 80, 80, 80);
-		private static readonly Brush BACKGROUND_DARK_BRUSH = new SolidBrush(BACKGROUND_DARK);
-		private static readonly Color BACKGROUND_ALTERNATIVE_DARK = Color.FromArgb(10, 255, 255, 255);
-		private static readonly Brush BACKGROUND_ALTERNATIVE_DARK_BRUSH = new SolidBrush(BACKGROUND_ALTERNATIVE_DARK);
-		private static readonly Color BACKGROUND_HOVER_DARK = Color.FromArgb(20, 255, 255, 255);
-		private static readonly Brush BACKGROUND_HOVER_DARK_BRUSH = new SolidBrush(BACKGROUND_HOVER_DARK);
-		private static readonly Color BACKGROUND_FOCUS_DARK = Color.FromArgb(30, 255, 255, 255);
-		private static readonly Brush BACKGROUND_FOCUS_DARK_BRUSH = new SolidBrush(BACKGROUND_FOCUS_DARK);
-		private static readonly Color BACKGROUND_DISABLED_DARK = Color.FromArgb(25, 255, 255, 255);
-		private static readonly Brush BACKGROUND_DISABLED_DARK_BRUSH = new SolidBrush(BACKGROUND_DISABLED_DARK);
-
-		// Backdrop colors - for containers, like forms or panels
-		private static readonly Color BACKDROP_DARK = Color.FromArgb(255, 50, 50, 50);
-		private static readonly Brush BACKDROP_DARK_BRUSH = new SolidBrush(BACKGROUND_DARK);
 
 	}
 }

--- a/MaterialSkin/Themes/ThemeLight.cs
+++ b/MaterialSkin/Themes/ThemeLight.cs
@@ -7,102 +7,44 @@ namespace MaterialSkin.Themes {
 		public ThemeLight() {
 
 			// Text
-			TextHighEmphasisColor = TEXT_HIGH_EMPHASIS_DARK;
+			TextHighEmphasisColor = Color.FromArgb(222, 0, 0, 0); // Alpha 87%
 
-			TextHighEmphasisBrush = TEXT_HIGH_EMPHASIS_DARK_BRUSH;
-			TextMediumEmphasisColor = TEXT_MEDIUM_EMPHASIS_DARK;
-			TextMediumEmphasisBrush = TEXT_MEDIUM_EMPHASIS_DARK_BRUSH;
-			TextDisabledOrHintColor = TEXT_DISABLED_OR_HINT_DARK;
-			TextDisabledOrHintBrush = TEXT_DISABLED_OR_HINT_DARK_BRUSH;
+			TextMediumEmphasisColor = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
+
+			TextDisabledOrHintColor = Color.FromArgb(97, 0, 0, 0); // Alpha 38%
 
 			// Divider
-			DividersColor = DIVIDERS_DARK;
+			DividersColor = Color.FromArgb(30, 0, 0, 0); // Alpha 30%
 
-			DividersBrush = DIVIDERS_DARK_BRUSH;
-			DividersAlternativeColor = DIVIDERS_ALTERNATIVE_DARK;
-			DividersAlternativeBrush = DIVIDERS_ALTERNATIVE_DARK_BRUSH;
+			DividersAlternativeColor = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
 
 			// Checkbox / Radio / Switch
-			CheckboxOffColor = CHECKBOX_OFF_LIGHT;
+			CheckboxOffColor = Color.FromArgb(138, 0, 0, 0);
 
-			CheckboxOffBrush = CHECKBOX_OFF_LIGHT_BRUSH;
-			CheckBoxOffDisabledColor = CHECKBOX_OFF_DISABLED_LIGHT;
-			CheckBoxOffDisabledBrush = CHECKBOX_OFF_DISABLED_LIGHT_BRUSH;
+			CheckBoxOffDisabledColor = Color.FromArgb(66, 0, 0, 0);
 
 			// Switch
-			SwitchOffColor = CHECKBOX_OFF_DARK;
+			SwitchOffColor = Color.FromArgb(179, 255, 255, 255);
 
-			SwitchOffThumbColor = SWITCH_OFF_THUMB_LIGHT;
-			SwitchOffTrackColor = SWITCH_OFF_TRACK_LIGHT;
-			SwitchOffDisabledThumbColor = SWITCH_OFF_DISABLED_THUMB_LIGHT;
+			SwitchOffThumbColor = Color.FromArgb(255, 255, 255, 255);
+			SwitchOffTrackColor = Color.FromArgb(100, 0, 0, 0);
+			SwitchOffDisabledThumbColor = Color.FromArgb(255, 230, 230, 230);
 
 			// Control Back colors
-			BackgroundColor = BACKGROUND_LIGHT;
+			BackgroundColor = Color.FromArgb(255, 255, 255, 255);
 
-			BackgroundBrush = BACKGROUND_LIGHT_BRUSH;
-			BackgroundAlternativeColor = BACKGROUND_ALTERNATIVE_LIGHT;
-			BackgroundAlternativeBrush = BACKGROUND_ALTERNATIVE_LIGHT_BRUSH;
-			BackgroundDisabledColor = BACKGROUND_DISABLED_LIGHT;
-			BackgroundDisabledBrush = BACKGROUND_DISABLED_LIGHT_BRUSH;
-			BackgroundHoverColor = BACKGROUND_HOVER_LIGHT;
-			BackgroundHoverBrush = BACKGROUND_HOVER_LIGHT_BRUSH;
-			BackgroundFocusColor = BACKGROUND_FOCUS_LIGHT;
-			BackgroundFocusBrush = BACKGROUND_FOCUS_LIGHT_BRUSH;
+			BackgroundAlternativeColor = Color.FromArgb(10, 0, 0, 0);
 
-			// Backdrop color
-			BackdropColor = BACKDROP_LIGHT;
+			BackgroundDisabledColor = Color.FromArgb(25, 0, 0, 0);
 
-			BackdropBrush = BACKDROP_LIGHT_BRUSH;
+			BackgroundHoverColor = Color.FromArgb(20, 0, 0, 0);
+
+			BackgroundFocusColor = Color.FromArgb(30, 0, 0, 0);
+
+			// Backdrop colors - for containers, like forms or panels
+			BackdropColor = Color.FromArgb(255, 242, 242, 242);
+			BackdropBrush = new SolidBrush(BackgroundColor); // not a bug?
 		}
-
-
-		// Text
-		private static readonly Color TEXT_HIGH_EMPHASIS_DARK = Color.FromArgb(222, 0, 0, 0); // Alpha 87%
-		private static readonly Brush TEXT_HIGH_EMPHASIS_DARK_BRUSH = new SolidBrush(TEXT_HIGH_EMPHASIS_DARK);
-
-		private static readonly Color TEXT_MEDIUM_EMPHASIS_DARK = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
-		private static readonly Brush TEXT_MEDIUM_EMPHASIS_DARK_BRUSH = new SolidBrush(TEXT_MEDIUM_EMPHASIS_DARK);
-
-		private static readonly Color TEXT_DISABLED_OR_HINT_DARK = Color.FromArgb(97, 0, 0, 0); // Alpha 38%
-		private static readonly Brush TEXT_DISABLED_OR_HINT_DARK_BRUSH = new SolidBrush(TEXT_DISABLED_OR_HINT_DARK);
-
-		// Dividers and thin lines
-		private static readonly Color DIVIDERS_DARK = Color.FromArgb(30, 0, 0, 0); // Alpha 30%
-		private static readonly Brush DIVIDERS_DARK_BRUSH = new SolidBrush(DIVIDERS_DARK);
-		private static readonly Color DIVIDERS_ALTERNATIVE_DARK = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
-		private static readonly Brush DIVIDERS_ALTERNATIVE_DARK_BRUSH = new SolidBrush(DIVIDERS_ALTERNATIVE_DARK);
-
-		// Checkbox / Radio / Switches
-		private static readonly Color CHECKBOX_OFF_LIGHT = Color.FromArgb(138, 0, 0, 0);
-
-		private static readonly Brush CHECKBOX_OFF_LIGHT_BRUSH = new SolidBrush(CHECKBOX_OFF_LIGHT);
-		private static readonly Color CHECKBOX_OFF_DARK = Color.FromArgb(179, 255, 255, 255);
-		private static readonly Color CHECKBOX_OFF_DISABLED_LIGHT = Color.FromArgb(66, 0, 0, 0);
-		private static readonly Brush CHECKBOX_OFF_DISABLED_LIGHT_BRUSH = new SolidBrush(CHECKBOX_OFF_DISABLED_LIGHT);
-
-		// Switch specific
-		private static readonly Color SWITCH_OFF_THUMB_LIGHT = Color.FromArgb(255, 255, 255, 255);
-
-		private static readonly Color SWITCH_OFF_TRACK_LIGHT = Color.FromArgb(100, 0, 0, 0);
-		private static readonly Color SWITCH_OFF_DISABLED_THUMB_LIGHT = Color.FromArgb(255, 230, 230, 230);
-
-		// Generic back colors - for user controls
-		private static readonly Color BACKGROUND_LIGHT = Color.FromArgb(255, 255, 255, 255);
-
-		private static readonly Brush BACKGROUND_LIGHT_BRUSH = new SolidBrush(BACKGROUND_LIGHT);
-		private static readonly Color BACKGROUND_ALTERNATIVE_LIGHT = Color.FromArgb(10, 0, 0, 0);
-		private static readonly Brush BACKGROUND_ALTERNATIVE_LIGHT_BRUSH = new SolidBrush(BACKGROUND_ALTERNATIVE_LIGHT);
-		private static readonly Color BACKGROUND_HOVER_LIGHT = Color.FromArgb(20, 0, 0, 0);
-		private static readonly Brush BACKGROUND_HOVER_LIGHT_BRUSH = new SolidBrush(BACKGROUND_HOVER_LIGHT);
-		private static readonly Color BACKGROUND_FOCUS_LIGHT = Color.FromArgb(30, 0, 0, 0);
-		private static readonly Brush BACKGROUND_FOCUS_LIGHT_BRUSH = new SolidBrush(BACKGROUND_FOCUS_LIGHT);
-		private static readonly Color BACKGROUND_DISABLED_LIGHT = Color.FromArgb(25, 0, 0, 0);
-		private static readonly Brush BACKGROUND_DISABLED_LIGHT_BRUSH = new SolidBrush(BACKGROUND_DISABLED_LIGHT);
-
-		// Backdrop colors - for containers, like forms or panels
-		private static readonly Color BACKDROP_LIGHT = Color.FromArgb(255, 242, 242, 242);
-
-		private static readonly Brush BACKDROP_LIGHT_BRUSH = new SolidBrush(BACKGROUND_LIGHT);
 
 	}
 }

--- a/MaterialSkin/Themes/ThemeLight.cs
+++ b/MaterialSkin/Themes/ThemeLight.cs
@@ -1,26 +1,26 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 namespace MaterialSkin.Themes {
 
 	public class ThemeLight : Theme {
 
-		public ThemeLight() {
+		private MaterialSkinManager skinManager;
+
+		public ThemeLight(MaterialSkinManager skinManager) {
+			this.skinManager = skinManager;
 
 			// Text
 			TextHighEmphasisColor = Color.FromArgb(222, 0, 0, 0); // Alpha 87%
-
 			TextMediumEmphasisColor = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
-
 			TextDisabledOrHintColor = Color.FromArgb(97, 0, 0, 0); // Alpha 38%
 
 			// Divider
 			DividersColor = Color.FromArgb(30, 0, 0, 0); // Alpha 30%
-
 			DividersAlternativeColor = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
 
 			// Checkbox / Radio / Switch
 			CheckboxOffColor = Color.FromArgb(138, 0, 0, 0);
-
 			CheckBoxOffDisabledColor = Color.FromArgb(66, 0, 0, 0);
 
 			// Switch
@@ -32,18 +32,24 @@ namespace MaterialSkin.Themes {
 
 			// Control Back colors
 			BackgroundColor = Color.FromArgb(255, 255, 255, 255);
-
 			BackgroundAlternativeColor = Color.FromArgb(10, 0, 0, 0);
-
 			BackgroundDisabledColor = Color.FromArgb(25, 0, 0, 0);
-
 			BackgroundHoverColor = Color.FromArgb(20, 0, 0, 0);
-
 			BackgroundFocusColor = Color.FromArgb(30, 0, 0, 0);
 
 			// Backdrop colors - for containers, like forms or panels
 			BackdropColor = Color.FromArgb(255, 242, 242, 242);
 			BackdropBrush = new SolidBrush(BackgroundColor); // not a bug?
+
+			// for controls
+			SwitchRippleColor = Color.Black;
+			DrawerLightness = 0f;
+		}
+
+
+		public override Color RippleColor {
+			get => skinManager.ColorScheme.PrimaryColor;
+			set => throw new InvalidOperationException();
 		}
 
 	}

--- a/MaterialSkin/Themes/ThemeLight.cs
+++ b/MaterialSkin/Themes/ThemeLight.cs
@@ -1,0 +1,108 @@
+﻿using System.Drawing;
+
+namespace MaterialSkin.Themes {
+
+	public class ThemeLight : Theme {
+
+		public ThemeLight() {
+
+			// Text
+			TextHighEmphasisColor = TEXT_HIGH_EMPHASIS_DARK;
+
+			TextHighEmphasisBrush = TEXT_HIGH_EMPHASIS_DARK_BRUSH;
+			TextMediumEmphasisColor = TEXT_MEDIUM_EMPHASIS_DARK;
+			TextMediumEmphasisBrush = TEXT_MEDIUM_EMPHASIS_DARK_BRUSH;
+			TextDisabledOrHintColor = TEXT_DISABLED_OR_HINT_DARK;
+			TextDisabledOrHintBrush = TEXT_DISABLED_OR_HINT_DARK_BRUSH;
+
+			// Divider
+			DividersColor = DIVIDERS_DARK;
+
+			DividersBrush = DIVIDERS_DARK_BRUSH;
+			DividersAlternativeColor = DIVIDERS_ALTERNATIVE_DARK;
+			DividersAlternativeBrush = DIVIDERS_ALTERNATIVE_DARK_BRUSH;
+
+			// Checkbox / Radio / Switch
+			CheckboxOffColor = CHECKBOX_OFF_LIGHT;
+
+			CheckboxOffBrush = CHECKBOX_OFF_LIGHT_BRUSH;
+			CheckBoxOffDisabledColor = CHECKBOX_OFF_DISABLED_LIGHT;
+			CheckBoxOffDisabledBrush = CHECKBOX_OFF_DISABLED_LIGHT_BRUSH;
+
+			// Switch
+			SwitchOffColor = CHECKBOX_OFF_DARK;
+
+			SwitchOffThumbColor = SWITCH_OFF_THUMB_LIGHT;
+			SwitchOffTrackColor = SWITCH_OFF_TRACK_LIGHT;
+			SwitchOffDisabledThumbColor = SWITCH_OFF_DISABLED_THUMB_LIGHT;
+
+			// Control Back colors
+			BackgroundColor = BACKGROUND_LIGHT;
+
+			BackgroundBrush = BACKGROUND_LIGHT_BRUSH;
+			BackgroundAlternativeColor = BACKGROUND_ALTERNATIVE_LIGHT;
+			BackgroundAlternativeBrush = BACKGROUND_ALTERNATIVE_LIGHT_BRUSH;
+			BackgroundDisabledColor = BACKGROUND_DISABLED_LIGHT;
+			BackgroundDisabledBrush = BACKGROUND_DISABLED_LIGHT_BRUSH;
+			BackgroundHoverColor = BACKGROUND_HOVER_LIGHT;
+			BackgroundHoverBrush = BACKGROUND_HOVER_LIGHT_BRUSH;
+			BackgroundFocusColor = BACKGROUND_FOCUS_LIGHT;
+			BackgroundFocusBrush = BACKGROUND_FOCUS_LIGHT_BRUSH;
+
+			// Backdrop color
+			BackdropColor = BACKDROP_LIGHT;
+
+			BackdropBrush = BACKDROP_LIGHT_BRUSH;
+		}
+
+
+		// Text
+		private static readonly Color TEXT_HIGH_EMPHASIS_DARK = Color.FromArgb(222, 0, 0, 0); // Alpha 87%
+		private static readonly Brush TEXT_HIGH_EMPHASIS_DARK_BRUSH = new SolidBrush(TEXT_HIGH_EMPHASIS_DARK);
+
+		private static readonly Color TEXT_MEDIUM_EMPHASIS_DARK = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
+		private static readonly Brush TEXT_MEDIUM_EMPHASIS_DARK_BRUSH = new SolidBrush(TEXT_MEDIUM_EMPHASIS_DARK);
+
+		private static readonly Color TEXT_DISABLED_OR_HINT_DARK = Color.FromArgb(97, 0, 0, 0); // Alpha 38%
+		private static readonly Brush TEXT_DISABLED_OR_HINT_DARK_BRUSH = new SolidBrush(TEXT_DISABLED_OR_HINT_DARK);
+
+		// Dividers and thin lines
+		private static readonly Color DIVIDERS_DARK = Color.FromArgb(30, 0, 0, 0); // Alpha 30%
+		private static readonly Brush DIVIDERS_DARK_BRUSH = new SolidBrush(DIVIDERS_DARK);
+		private static readonly Color DIVIDERS_ALTERNATIVE_DARK = Color.FromArgb(153, 0, 0, 0); // Alpha 60%
+		private static readonly Brush DIVIDERS_ALTERNATIVE_DARK_BRUSH = new SolidBrush(DIVIDERS_ALTERNATIVE_DARK);
+
+		// Checkbox / Radio / Switches
+		private static readonly Color CHECKBOX_OFF_LIGHT = Color.FromArgb(138, 0, 0, 0);
+
+		private static readonly Brush CHECKBOX_OFF_LIGHT_BRUSH = new SolidBrush(CHECKBOX_OFF_LIGHT);
+		private static readonly Color CHECKBOX_OFF_DARK = Color.FromArgb(179, 255, 255, 255);
+		private static readonly Color CHECKBOX_OFF_DISABLED_LIGHT = Color.FromArgb(66, 0, 0, 0);
+		private static readonly Brush CHECKBOX_OFF_DISABLED_LIGHT_BRUSH = new SolidBrush(CHECKBOX_OFF_DISABLED_LIGHT);
+
+		// Switch specific
+		private static readonly Color SWITCH_OFF_THUMB_LIGHT = Color.FromArgb(255, 255, 255, 255);
+
+		private static readonly Color SWITCH_OFF_TRACK_LIGHT = Color.FromArgb(100, 0, 0, 0);
+		private static readonly Color SWITCH_OFF_DISABLED_THUMB_LIGHT = Color.FromArgb(255, 230, 230, 230);
+
+		// Generic back colors - for user controls
+		private static readonly Color BACKGROUND_LIGHT = Color.FromArgb(255, 255, 255, 255);
+
+		private static readonly Brush BACKGROUND_LIGHT_BRUSH = new SolidBrush(BACKGROUND_LIGHT);
+		private static readonly Color BACKGROUND_ALTERNATIVE_LIGHT = Color.FromArgb(10, 0, 0, 0);
+		private static readonly Brush BACKGROUND_ALTERNATIVE_LIGHT_BRUSH = new SolidBrush(BACKGROUND_ALTERNATIVE_LIGHT);
+		private static readonly Color BACKGROUND_HOVER_LIGHT = Color.FromArgb(20, 0, 0, 0);
+		private static readonly Brush BACKGROUND_HOVER_LIGHT_BRUSH = new SolidBrush(BACKGROUND_HOVER_LIGHT);
+		private static readonly Color BACKGROUND_FOCUS_LIGHT = Color.FromArgb(30, 0, 0, 0);
+		private static readonly Brush BACKGROUND_FOCUS_LIGHT_BRUSH = new SolidBrush(BACKGROUND_FOCUS_LIGHT);
+		private static readonly Color BACKGROUND_DISABLED_LIGHT = Color.FromArgb(25, 0, 0, 0);
+		private static readonly Brush BACKGROUND_DISABLED_LIGHT_BRUSH = new SolidBrush(BACKGROUND_DISABLED_LIGHT);
+
+		// Backdrop colors - for containers, like forms or panels
+		private static readonly Color BACKDROP_LIGHT = Color.FromArgb(255, 242, 242, 242);
+
+		private static readonly Brush BACKDROP_LIGHT_BRUSH = new SolidBrush(BACKGROUND_LIGHT);
+
+	}
+}

--- a/MaterialSkinExample/MainForm.cs
+++ b/MaterialSkinExample/MainForm.cs
@@ -1,5 +1,6 @@
 ﻿using MaterialSkin;
 using MaterialSkin.Controls;
+using MaterialSkin.Themes;
 using System;
 using System.Text;
 using System.Windows.Forms;
@@ -23,8 +24,8 @@ namespace MaterialSkinExample
 
             // MaterialSkinManager properties
             materialSkinManager.AddFormToManage(this);
-            materialSkinManager.Theme = MaterialSkinManager.Themes.LIGHT;
-            materialSkinManager.ColorScheme = new ColorScheme(Primary.Indigo500, Primary.Indigo700, Primary.Indigo100, Accent.Pink200, TextShade.WHITE);
+			materialSkinManager.SetThemes(new ThemeLight(materialSkinManager), new ThemeDark(materialSkinManager), true);
+			materialSkinManager.ColorScheme = new ColorScheme(Primary.Indigo500, Primary.Indigo700, Primary.Indigo100, Accent.Pink200, TextShade.WHITE);
 
             // Add dummy data to the listview
             seedListView();
@@ -61,7 +62,7 @@ namespace MaterialSkinExample
 
         private void materialButton1_Click(object sender, EventArgs e)
         {
-            materialSkinManager.Theme = materialSkinManager.Theme == MaterialSkinManager.Themes.DARK ? MaterialSkinManager.Themes.LIGHT : MaterialSkinManager.Themes.DARK;
+			materialSkinManager.SwitchTheme(MaterialSkinManager.ThemeSelector.Opposite);
             updateColor();
         }
 
@@ -82,9 +83,9 @@ namespace MaterialSkinExample
             {
                 case 0:
                     materialSkinManager.ColorScheme = new ColorScheme(
-                        materialSkinManager.Theme == MaterialSkinManager.Themes.DARK ? Primary.Teal500 : Primary.Indigo500,
-                        materialSkinManager.Theme == MaterialSkinManager.Themes.DARK ? Primary.Teal700 : Primary.Indigo700,
-                        materialSkinManager.Theme == MaterialSkinManager.Themes.DARK ? Primary.Teal200 : Primary.Indigo100,
+                        !materialSkinManager.EnabledLightTheme ? Primary.Teal500 : Primary.Indigo500,
+						!materialSkinManager.EnabledLightTheme ? Primary.Teal700 : Primary.Indigo700,
+						!materialSkinManager.EnabledLightTheme ? Primary.Teal200 : Primary.Indigo100,
                         Accent.Pink200,
                         TextShade.WHITE);
                     break;

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ public Form1()
 
     var materialSkinManager = MaterialSkinManager.Instance;
     materialSkinManager.AddFormToManage(this);
-    materialSkinManager.Theme = MaterialSkinManager.Themes.LIGHT;
+    materialSkinManager.Theme = new ThemeLight(materialSkinManager);
     materialSkinManager.ColorScheme = new ColorScheme(Primary.BlueGrey800, Primary.BlueGrey900, Primary.BlueGrey500, Accent.LightBlue200, TextShade.WHITE);
 }
 ```
@@ -140,7 +140,7 @@ Public Class Form1
     Private Sub Form1_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         Dim SkinManager As MaterialSkinManager = MaterialSkinManager.Instance
         SkinManager.AddFormToManage(Me)
-        SkinManager.Theme = MaterialSkinManager.Themes.LIGHT
+        SkinManager.Theme = New ThemeLight(SkinManager)
         SkinManager.ColorScheme = New ColorScheme(Primary.BlueGrey800, Primary.BlueGrey900, Primary.BlueGrey500, Accent.LightBlue200, TextShade.WHITE)
     End Sub
 End Class


### PR DESCRIPTION
Originally, `MaterialSkinManager` accepted either a light or dark theme, both being predefined. There was no option to customize the themes or have a different background color of the window (none that I'm aware of).

I added the ability to customize an existing theme or create a new one, together with an easy mechanism for switching themes.

I'm not very content of the circular dependency:
```
materialSkinManager.Theme = new ThemeLight(materialSkinManager);
```
but I added it to keep the existing behavior.

I was also wondering whether `BackdropBrush` is correctly set - in both cases it was set to a brush from `BackgroundColor` instead of `BackdropColor`. Let me know.

Thanks