### PR TITLE
Add Tab Icons into MaterialTabSelector

### DIFF
--- a/MaterialSkin/Controls/MaterialTabSelector.cs
+++ b/MaterialSkin/Controls/MaterialTabSelector.cs
@@ -1,6 +1,7 @@
 ﻿namespace MaterialSkin.Controls
 {
     using MaterialSkin.Animations;
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Drawing;
@@ -28,6 +29,9 @@
             {
                 _baseTabControl = value;
                 if (_baseTabControl == null) return;
+
+                UpdateTabRects();
+
                 _previousSelectedTabIndex = _baseTabControl.SelectedIndex;
                 _baseTabControl.Deselected += (sender, args) =>
                 {
@@ -69,7 +73,13 @@
             get { return _tab_indicator_height; }
             set
             {
-                _tab_indicator_height = value;
+                if (value < 1)
+                    throw new ArgumentOutOfRangeException("Tab Indicator Height", value, "Value should be > 0");
+                else
+                {
+                    _tab_indicator_height = value;
+                    Refresh();
+                }
             }
         }
 
@@ -130,9 +140,11 @@
             {
                 var currentTabIndex = _baseTabControl.TabPages.IndexOf(tabPage);
 
+                // Text
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                 {
-                    Rectangle textLocation = _tabRects[currentTabIndex];
+                    var IconWidth = String.IsNullOrEmpty(tabPage.ImageKey) && tabPage.ImageIndex == -1 ? 0 : _baseTabControl.ImageList.ImageSize.Width/2;
+                    Rectangle textLocation = new Rectangle(_tabRects[currentTabIndex].X + IconWidth, _tabRects[currentTabIndex].Y, _tabRects[currentTabIndex].Width, _tabRects[currentTabIndex].Height);
                     NativeText.DrawTransparentText(
                         tabPage.Text.ToUpper(),
                         SkinManager.getLogFontByType(MaterialSkinManager.fontType.Button),
@@ -141,7 +153,19 @@
                         textLocation.Size,
                         NativeTextRenderer.TextAlignFlags.Center | NativeTextRenderer.TextAlignFlags.Middle);
                 }
-            }
+ 
+                // Icons
+                if (_baseTabControl.ImageList != null && (!String.IsNullOrEmpty(tabPage.ImageKey) | tabPage.ImageIndex > -1))
+                {
+                    Size ImageSize = !String.IsNullOrEmpty(tabPage.ImageKey) ? _baseTabControl.ImageList.Images[tabPage.ImageKey].Size : _baseTabControl.ImageList.Images[tabPage.ImageIndex].Size ;
+                    Rectangle iconRect = new Rectangle(
+                        _tabRects[currentTabIndex].X + (Height / 2) - (ImageSize.Width / 2),
+                        _tabRects[currentTabIndex].Y + (Height / 2) - (ImageSize.Height / 2),
+                        ImageSize.Width, ImageSize.Height);
+                    g.DrawImage(!String.IsNullOrEmpty(tabPage.ImageKey) ? _baseTabControl.ImageList.Images[tabPage.ImageKey]: _baseTabControl.ImageList.Images[tabPage.ImageIndex], iconRect);
+                }
+                    
+           }
 
             //Animate tab indicator
             var previousSelectedTabIndexIfHasOne = _previousSelectedTabIndex == -1 ? _baseTabControl.SelectedIndex : _previousSelectedTabIndex;
@@ -218,6 +242,20 @@
                 Invalidate();
         }
 
+        protected override void OnMouseLeave(EventArgs e)
+        {
+            base.OnMouseLeave(e);
+            if (DesignMode)
+                return;
+
+            if (_tabRects == null)
+                UpdateTabRects();
+
+            Cursor = Cursors.Arrow;
+            _tab_over_index = -1;
+            Invalidate();
+        }
+
         private void UpdateTabRects()
         {
             _tabRects = new List<Rectangle>();
@@ -231,10 +269,15 @@
             {
                 using (var g = Graphics.FromImage(b))
                 {
-                    _tabRects.Add(new Rectangle(SkinManager.FORM_PADDING, 0, TAB_HEADER_PADDING * 2 + (int)g.MeasureString(_baseTabControl.TabPages[0].Text, Font).Width, Height));
+                    int ImgWidth=0;
+                    if (_baseTabControl.ImageList != null && (!String.IsNullOrEmpty(_baseTabControl.TabPages[0].ImageKey) | _baseTabControl.TabPages[0].ImageIndex > -1)) ImgWidth = _baseTabControl.ImageList.ImageSize.Width;
+                    Size textSize = TextRenderer.MeasureText(_baseTabControl.TabPages[0].Text, Font);
+                    _tabRects.Add(new Rectangle(SkinManager.FORM_PADDING, 0, (TAB_HEADER_PADDING * 2) + textSize.Width + ImgWidth, Height));
                     for (int i = 1; i < _baseTabControl.TabPages.Count; i++)
                     {
-                        _tabRects.Add(new Rectangle(_tabRects[i - 1].Right, 0, TAB_HEADER_PADDING * 2 + (int)g.MeasureString(_baseTabControl.TabPages[i].Text, Font).Width, Height));
+                        if (_baseTabControl.ImageList != null && (!String.IsNullOrEmpty(_baseTabControl.TabPages[i].ImageKey) | _baseTabControl.TabPages[i].ImageIndex > -1)) { ImgWidth = _baseTabControl.ImageList.ImageSize.Width; } else { ImgWidth = 0; };
+                        textSize = TextRenderer.MeasureText(_baseTabControl.TabPages[i].Text, Font);
+                        _tabRects.Add(new Rectangle(_tabRects[i - 1].Right, 0, (TAB_HEADER_PADDING * 2) + textSize.Width + ImgWidth, Height));
                     }
                 }
             }


### PR DESCRIPTION
This update add tab icons before text in MaterialTabSelector. It takes in charge both ImageKey or ImageIndex property from Tab object. 
It use "DrawImage" and so it doesn't take in account theme color for icon. But I guess we can consider that as a first step improvement. 
However if anyone could help to add theme color on icon in a next PR I would appreciate that.

There is also small fix by adding OnMouseLeave event to disable tab hover color when mouse leave control.