### PR TITLE
Combobox Fix: Works with List <T> where T = class and DataTable

### DIFF
--- a/MaterialSkin/Controls/MaterialComboBox.cs
+++ b/MaterialSkin/Controls/MaterialComboBox.cs
@@ -5,6 +5,7 @@
     using System.ComponentModel;
     using System.Drawing;
     using System.Linq;
+    using System.Data;
     using System.Windows.Forms;
 
     public class MaterialComboBox : ComboBox, IMaterialControl
@@ -284,7 +285,16 @@
             string Text = "";
             if (!string.IsNullOrWhiteSpace(DisplayMember))
             {
-                Text = Items[e.Index].GetType().GetProperty(DisplayMember).GetValue(Items[e.Index], null).ToString();
+                if (!Items[e.Index].GetType().Equals(typeof(DataRowView)))
+                {
+                    var item = Items[e.Index].GetType().GetProperty(DisplayMember).GetValue(Items[e.Index]);
+                    Text = item.ToString();
+                }
+                else
+                {
+                    var table = ((DataRow)Items[e.Index].GetType().GetProperty("Row").GetValue(Items[e.Index])).Table;
+                    Text = table.Rows[e.Index][DisplayMember].ToString();
+                }
             }
             else
             {

--- a/MaterialSkin/MaterialSkin.csproj
+++ b/MaterialSkin/MaterialSkin.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION
[#61](https://github.com/leocb/MaterialSkin/issues/61) ComboBox.DisplayMember fix. NullReference error.

Fixed for the new version. Which by the way the new implementations were very good

