### PR TITLE
Fix Designer resizing form due to the WS_SIZEFRAME style flag

### DIFF
--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -722,7 +722,11 @@
                 // WS_SYSMENU: Trigger the creation of the system menu
                 // WS_MINIMIZEBOX: Allow minimizing from taskbar
                 // WS_SIZEFRAME: Required for Aero Snapping
-                par.Style = par.Style | WS_MINIMIZEBOX | WS_SYSMENU | WS_SIZEFRAME; // Turn on the WS_MINIMIZEBOX style flag
+                par.Style |= WS_MINIMIZEBOX | WS_SYSMENU; // Turn on the WS_MINIMIZEBOX style flag
+
+                if (!DesignMode)
+                    par.Style |= WS_SIZEFRAME;
+
                 return par;
             }
         }


### PR DESCRIPTION
This should close #227. I was unable to see the issues I was experiencing the other night on this branch, so this should properly implement Aero Snapping. I will continue exploring with my other branch to reproduce the issue I noticed with the WM_NCCALCSIZE Windows Message.