### PR TITLE
All windows closing when close the sub window

### DIFF
--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -641,8 +641,6 @@
             drawerControl.DrawerShowIconsWhenHiddenChanged += FixFormPadding;
             FixFormPadding(this);
 
-            // Fix Closing the Drawer or Overlay form with Alt+F4 not exiting the app
-            drawerOverlay.FormClosed += TerminateOnClose;
             drawerForm.FormClosed += TerminateOnClose;
         }
 


### PR DESCRIPTION
All windows closing when If the child window whose DrawerTabControl field is not empty is closed.