### PR TITLE
LeaveOnEnterKey property added for Material TextBoxes.

### DIFF
--- a/MaterialSkin/Controls/MaterialMaskedTextBox.cs
+++ b/MaterialSkin/Controls/MaterialMaskedTextBox.cs
@@ -341,7 +341,7 @@
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin")]
+        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;

--- a/MaterialSkin/Controls/MaterialMaskedTextBox.cs
+++ b/MaterialSkin/Controls/MaterialMaskedTextBox.cs
@@ -339,6 +339,27 @@
             }
         }
 
+        private bool _leaveOnEnterKey;
+
+        [Category("Material Skin")]
+        public bool LeaveOnEnterKey
+        {
+            get => _leaveOnEnterKey;
+            set
+            {
+                _leaveOnEnterKey = value;
+                if (value)
+                {
+                    baseTextBox.KeyDown += new KeyEventHandler(LeaveOnEnterKey_KeyDown);
+                }
+                else
+                {
+                    baseTextBox.KeyDown -= LeaveOnEnterKey_KeyDown;
+                }
+                Invalidate();
+            }
+        }
+
         public void SelectAll() { baseTextBox.SelectAll(); }
 
         public void Clear() { baseTextBox.Clear(); }
@@ -1705,8 +1726,7 @@
 
         }
 
-#region Icon
-
+        #region Icon
         private static Size ResizeIcon(Image Icon)
         {
             int newWidth, newHeight;
@@ -1902,8 +1922,7 @@
                 iconsErrorBrushes.Add("_trailingIcon", textureBrushRed);
             }
         }
-        
-#endregion
+        #endregion
 
         private void UpdateHeight()
         {
@@ -2017,5 +2036,14 @@
             }
         }
 
+        private void LeaveOnEnterKey_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Enter)
+            {
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+                SendKeys.Send("{TAB}");
+            }
+        }
     }
 }

--- a/MaterialSkin/Controls/MaterialMultiLineTextBox.cs
+++ b/MaterialSkin/Controls/MaterialMultiLineTextBox.cs
@@ -43,7 +43,7 @@
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin")]
+        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed. To add enter in text, the user must press CTRL+Enter")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;

--- a/MaterialSkin/Controls/MaterialMultiLineTextBox.cs
+++ b/MaterialSkin/Controls/MaterialMultiLineTextBox.cs
@@ -41,6 +41,27 @@
             }
         }
 
+        private bool _leaveOnEnterKey;
+
+        [Category("Material Skin")]
+        public bool LeaveOnEnterKey
+        {
+            get => _leaveOnEnterKey;
+            set
+            {
+                _leaveOnEnterKey = value;
+                if (value)
+                {
+                    KeyDown += new KeyEventHandler(LeaveOnEnterKey_KeyDown);
+                }
+                else
+                {
+                    KeyDown -= LeaveOnEnterKey_KeyDown;
+                }
+                Invalidate();
+            }
+        }
+
         public new void SelectAll()
         {
             BeginInvoke((MethodInvoker)delegate ()
@@ -56,6 +77,16 @@
             {
                 base.Focus();
             });
+        }
+
+        private void LeaveOnEnterKey_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Enter && e.Control == false)
+            {
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+                SendKeys.Send("{TAB}");
+            }
         }
 
         public MaterialMultiLineTextBox()

--- a/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
+++ b/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
@@ -167,7 +167,7 @@ using MaterialSkin.Animations;
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin")]
+        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;

--- a/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
+++ b/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
@@ -167,7 +167,7 @@ using MaterialSkin.Animations;
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
+        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed. To add enter in text, the user must press CTRL+Enter")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;

--- a/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
+++ b/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
@@ -165,6 +165,27 @@ using MaterialSkin.Animations;
             }
         }
 
+        private bool _leaveOnEnterKey;
+
+        [Category("Material Skin")]
+        public bool LeaveOnEnterKey
+        {
+            get => _leaveOnEnterKey;
+            set
+            {
+                _leaveOnEnterKey = value;
+                if (value)
+                {
+                    baseTextBox.KeyDown += new KeyEventHandler(LeaveOnEnterKey_KeyDown);
+                }
+                else
+                {
+                    baseTextBox.KeyDown -= LeaveOnEnterKey_KeyDown;
+                }
+                Invalidate();
+            }
+        }
+
         public void SelectAll() { baseTextBox.SelectAll(); }
 
         public void Clear() { baseTextBox.Clear(); }
@@ -1317,5 +1338,14 @@ using MaterialSkin.Animations;
             }
         }
 
+        private void LeaveOnEnterKey_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Enter && e.Control == false)
+            {
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+                SendKeys.Send("{TAB}");
+            }
+        }
     }
 }

--- a/MaterialSkin/Controls/MaterialTextBox.cs
+++ b/MaterialSkin/Controls/MaterialTextBox.cs
@@ -183,6 +183,27 @@
             }
         }
 
+        private bool _leaveOnEnterKey;
+
+        [Category("Material Skin")]
+        public bool LeaveOnEnterKey
+        {
+            get => _leaveOnEnterKey;
+            set
+            {
+                _leaveOnEnterKey = value;
+                if (value)
+                {
+                    KeyDown += new KeyEventHandler(LeaveOnEnterKey_KeyDown);
+                }
+                else
+                {
+                    KeyDown -= LeaveOnEnterKey_KeyDown;
+                }
+                Invalidate();
+            }
+        }
+
         #region "Events"
 
         [Category("Action")]
@@ -794,6 +815,16 @@
                 strip.Paste.Enabled = Clipboard.ContainsText() && !ReadOnly;
                 strip.Delete.Enabled = !string.IsNullOrEmpty(SelectedText) && !ReadOnly;
                 strip.SelectAll.Enabled = !string.IsNullOrEmpty(Text);
+            }
+        }
+
+        private void LeaveOnEnterKey_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+                SendKeys.Send("{TAB}");
             }
         }
 

--- a/MaterialSkin/Controls/MaterialTextBox.cs
+++ b/MaterialSkin/Controls/MaterialTextBox.cs
@@ -185,7 +185,7 @@
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin")]
+        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;

--- a/MaterialSkin/Controls/MaterialTextBox2.cs
+++ b/MaterialSkin/Controls/MaterialTextBox2.cs
@@ -301,7 +301,7 @@ namespace MaterialSkin.Controls
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin")]
+        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;

--- a/MaterialSkin/Controls/MaterialTextBox2.cs
+++ b/MaterialSkin/Controls/MaterialTextBox2.cs
@@ -299,6 +299,27 @@ namespace MaterialSkin.Controls
             }
         }
 
+        private bool _leaveOnEnterKey;
+
+        [Category("Material Skin")]
+        public bool LeaveOnEnterKey
+        {
+            get => _leaveOnEnterKey;
+            set
+            {
+                _leaveOnEnterKey = value;
+                if (value)
+                {
+                    baseTextBox.KeyDown += new KeyEventHandler(LeaveOnEnterKey_KeyDown);
+                }
+                else
+                {
+                    baseTextBox.KeyDown -= LeaveOnEnterKey_KeyDown;
+                }
+                Invalidate();
+            }
+        }
+
         public void SelectAll() { baseTextBox.SelectAll(); }
 
         public void Clear() { baseTextBox.Clear(); }
@@ -1928,5 +1949,14 @@ namespace MaterialSkin.Controls
             }
         }
 
+        private void LeaveOnEnterKey_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+                SendKeys.Send("{TAB}");
+            }
+        }
     }
 }


### PR DESCRIPTION
Implemented `LeaveOnEnterKey` property on all textboxes controls. This property will allow you to select the next control which have `TabStop` property on `True`, if this property is set to `True`.
By default, it is `False`, to preserve current approach of Material TextBox controls. 

Mention:
On MultiLine controls, to be able to add Carriage Return (`Enter` key) in text, the user must press `CTRL`+`Enter`, if this property is set to `True`. 