### PR TITLE
Material Scrim

### DIFF
--- a/MaterialSkin/Controls/FlexibleMaterialDialog.cs
+++ b/MaterialSkin/Controls/FlexibleMaterialDialog.cs
@@ -813,7 +813,12 @@ namespace MaterialSkin.Controls
             SetDialogStartPosition(FlexibleMaterialForm, owner);
 
             //Show the dialog
-            return FlexibleMaterialForm.ShowDialog(owner);
+            var form = owner as Form;
+
+            form?.ShowScrim();
+            var dialogResult = FlexibleMaterialForm.ShowDialog(owner);
+            form?.HideScrim();
+            return dialogResult;
         }
 
         private void FlexibleMaterialForm_Load(object sender, EventArgs e)

--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -386,7 +386,7 @@ namespace MaterialSkin.Controls
         private Point _animationSource;
         private Padding originalPadding;
 
-        private Form drawerOverlay = new Form();
+        private DrawerScrim drawerOverlay;
         private Form drawerForm = new Form();
 
         // Drawer overlay and speed improvements
@@ -454,29 +454,16 @@ namespace MaterialSkin.Controls
                 Increment = 0.04
             };
 
+            // Overlay Form definitions
+            drawerOverlay = new DrawerScrim(this);
+
             _drawerShowHideAnimManager.OnAnimationProgress += (sender) =>
             {
-                drawerOverlay.Opacity = (float)(_drawerShowHideAnimManager.GetProgress() * 0.55f);
+                drawerOverlay.Opacity = _drawerShowHideAnimManager.GetProgress() * 0.55;
             };
 
             int H = ClientSize.Height - _statusBarBounds.Height - _actionBarBounds.Height;
             int Y = PointToScreen(Point.Empty).Y + _statusBarBounds.Height + _actionBarBounds.Height;
-
-            // Overlay Form definitions
-            drawerOverlay.BackColor = Color.Black;
-            drawerOverlay.Opacity = 0;
-            drawerOverlay.MinimizeBox = false;
-            drawerOverlay.MaximizeBox = false;
-            drawerOverlay.Text = "";
-            drawerOverlay.ShowIcon = false;
-            drawerOverlay.ControlBox = false;
-            drawerOverlay.FormBorderStyle = FormBorderStyle.None;
-            drawerOverlay.Visible = true;
-            drawerOverlay.Size = new Size(ClientSize.Width, H);
-            drawerOverlay.Location = new Point(PointToScreen(Point.Empty).X, Y);
-            drawerOverlay.ShowInTaskbar = false;
-            drawerOverlay.Owner = this;
-            drawerOverlay.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right | AnchorStyles.Bottom;
 
             // Drawer Form definitions
             drawerForm.BackColor = Color.LimeGreen;
@@ -532,14 +519,12 @@ namespace MaterialSkin.Controls
             {
                 H = ClientSize.Height - _statusBarBounds.Height - _actionBarBounds.Height;
                 drawerForm.Size = new Size(DrawerWidth, H);
-                drawerOverlay.Size = new Size(ClientSize.Width, H);
             };
 
             Move += (sender, e) =>
             {
                 Point pos = new Point(PointToScreen(Point.Empty).X, PointToScreen(Point.Empty).Y + _statusBarBounds.Height + _actionBarBounds.Height);
                 drawerForm.Location = pos;
-                drawerOverlay.Location = pos;
             };
 
             // Close when click outside menu
@@ -593,7 +578,6 @@ namespace MaterialSkin.Controls
             FixFormPadding(this);
 
             // Fix Closing the Drawer or Overlay form with Alt+F4 not exiting the app
-            drawerOverlay.FormClosed += TerminateOnClose;
             drawerForm.FormClosed += TerminateOnClose;
         }
 

--- a/MaterialSkin/Controls/MaterialScrim.cs
+++ b/MaterialSkin/Controls/MaterialScrim.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace MaterialSkin.Controls
+{
+    public class MaterialScrim : Form
+    {
+        public new double Opacity
+        {
+            get => base.Opacity;
+            set
+            {
+                if (value == base.Opacity) return;
+
+                Visible = value != 0;
+                base.Opacity = value;
+            }
+        }
+
+        public MaterialScrim(Form owner)
+        {
+            InitializeComponent();
+
+            Owner = owner ?? throw new ArgumentNullException(nameof(owner));
+            Size = Owner.Size;
+            Location = Owner.Location;
+
+            Owner.Resize += (sender, e) => OnResize(e);
+            Owner.Move += (sender, e) => OnMove(e);
+            Owner.FormClosed += (sender, e) => OnFormClosed(e);
+            Owner.Disposed += (sender, e) => Dispose();
+            Owner.VisibleChanged += (sender, e) => OnVisibleChanged(e);
+        }
+
+        private void InitializeComponent()
+        {
+            BackColor = Color.Black;
+            Opacity = 0;
+            MinimizeBox = false;
+            MaximizeBox = false;
+            ShowIcon = false;
+            ControlBox = false;
+            Text = string.Empty;
+            FormBorderStyle = FormBorderStyle.None;
+            ShowInTaskbar = false;
+        }
+
+        public new void Show() => Opacity = 0.55;
+
+        public new void Hide() => Opacity = 0;
+
+        protected override void OnResize(EventArgs e)
+        {
+            if (Owner == null) return;
+            Size = Owner.Size;
+        }
+
+        protected override void OnMove(EventArgs e)
+        {
+            if (Owner == null) return;
+            Location = Owner.Location;
+        }
+    }
+
+    public static class ScrimExtensions
+    {
+        public static void ShowScrim(this Form form) => GetScrim(form).Show();
+
+        public static void HideScrim(this Form form) => GetScrim(form).Hide();
+
+        private static MaterialScrim GetScrim(Form form)
+        {
+            var scrims = form.OwnedForms.Where(f => f is MaterialScrim);
+            MaterialScrim scrim;
+
+            if (!scrims.Any())
+                scrim = new MaterialScrim(form);
+            else
+                scrim = scrims.First() as MaterialScrim;
+
+            return scrim;
+        }
+    }
+
+    public class DrawerScrim : MaterialScrim
+    {
+        public DrawerScrim(MaterialForm owner) : base(owner)
+        {
+            var rect = owner.RectangleToScreen(owner.UserArea);
+
+            Size = rect.Size;
+            Location = rect.Location;
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            if (Owner == null) return;
+            Size = (Owner as MaterialForm).UserArea.Size;
+        }
+
+        protected override void OnMove(EventArgs e)
+        {
+            if (Owner == null) return;
+            Location = Owner.RectangleToScreen((Owner as MaterialForm).UserArea).Location;
+        }
+    }
+}

--- a/MaterialSkin/MaterialSkin.csproj
+++ b/MaterialSkin/MaterialSkin.csproj
@@ -53,6 +53,9 @@
     <Compile Include="Controls\MaterialListBox.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Controls\MaterialScrim.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Controls\MaterialScrollBar.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
Per the Material Design style, a scrim should be used any time the main application should lose focus for a child window. Since it should only apply to child windows, I've restricted what can create the scrim and what can't. The goal here is to eventually allow all children to force a scrim to be shown.

Additionally, this simplifies the necessity to create your own scrim in numerous places and allows library users to invoke the scrim themselves. For now, I've made it as simple as `Form.ShowScrim()` and `Form.HideScrim()`. I want to additional features to it in the future, but work has been keeping me from committing much time to this library as I'd like.