### PR TITLE
Calculate MaximizedBounds OnMove

### DIFF
--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -411,7 +411,6 @@ namespace MaterialSkin.Controls
 
         public MaterialForm()
         {
-            MaximizedBounds = Screen.GetWorkingArea(Location);
             DrawerWidth = 200;
             DrawerIsOpen = false;
             DrawerShowIconsWhenHidden = false;
@@ -851,6 +850,13 @@ namespace MaterialSkin.Controls
                     base.ContextMenuStrip = user_cms;
                 }
             }
+        }
+
+        protected override void OnMove(EventArgs e)
+        {
+            // Empty Point ensures the screen maximizes to the top left of the current screen
+            MaximizedBounds = new Rectangle(Point.Empty, Screen.GetWorkingArea(Location).Size);
+            base.OnMove(e);
         }
 
         protected override void OnMouseDown(MouseEventArgs e)


### PR DESCRIPTION
I'm not sure this is the best approach, however, it should resolve #277. I believe the Windows message for Min/Max Info might be a better approach but is significantly more involved.

Edit: A noted side effect of this change is that the form actually starts on the same monitor as the IDE instead of just the main monitor. Please note this is intentional behavior for WinForms, it was apparently just broken previously.