### PR TITLE
Scrollable Drawer on MouseWheel and Click'n'Move implementation

### DIFF
--- a/MaterialSkin/Controls/MaterialDrawer.cs
+++ b/MaterialSkin/Controls/MaterialDrawer.cs
@@ -362,6 +362,29 @@
                 Increment = 0.04
             };
             _clickAnimManager.OnAnimationProgress += sender => Invalidate();
+
+            MouseWheel += MaterialDrawer_MouseWheel;
+        }
+
+        private void MaterialDrawer_MouseWheel(object sender, MouseEventArgs e)
+        {
+            int step = 20;
+            if (e.Delta > 0)
+            {
+                if (this.Location.Y < 0)
+                {
+                    this.Location = new Point(this.Location.X, (this.Location.Y + step));
+                    this.Height -= step;
+                }
+            }
+            else
+            {
+                if (this.Height < (8 + drawerItemHeight) * _drawerItemRects.Count)
+                {
+                    this.Location = new Point(this.Location.X, (this.Location.Y - step));
+                    this.Height += step;
+                }
+            }
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -394,7 +394,7 @@ namespace MaterialSkin.Controls
         private Padding originalPadding;
 
         private Form drawerOverlay = new Form();
-        private Form drawerForm = new Form();
+        private MaterialDrawerForm drawerForm = new MaterialDrawerForm();
 
         // Drawer overlay and speed improvements
         private bool _drawerShowIconsWhenHidden;
@@ -601,6 +601,7 @@ namespace MaterialSkin.Controls
             // Fix Closing the Drawer or Overlay form with Alt+F4 not exiting the app
             drawerOverlay.FormClosed += TerminateOnClose;
             drawerForm.FormClosed += TerminateOnClose;
+            drawerForm.Attach(drawerControl);
         }
 
         private void TerminateOnClose(object sender, FormClosedEventArgs e)
@@ -1238,5 +1239,26 @@ namespace MaterialSkin.Controls
         [DllImport("user32.dll")]
         private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
         #endregion
+    }
+
+    public class MaterialDrawerForm : Form
+    {
+        public MouseWheelRedirector MouseWheelRedirector;
+
+        public MaterialDrawerForm()
+        {
+            MouseWheelRedirector = new MouseWheelRedirector();
+            SetStyle(ControlStyles.Selectable | ControlStyles.OptimizedDoubleBuffer | ControlStyles.EnableNotifyMessage, true);
+        }
+
+        public void Attach(Control control)
+        {
+            MouseWheelRedirector.Attach(control);
+        }
+
+        public void Detach(Control control)
+        {
+            MouseWheelRedirector.Detach(control);
+        }
     }
 }

--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -394,7 +394,7 @@ namespace MaterialSkin.Controls
         private Padding originalPadding;
 
         private Form drawerOverlay = new Form();
-        private MaterialDrawerForm drawerForm = new MaterialDrawerForm();
+        private Form drawerForm = new Form();
 
         // Drawer overlay and speed improvements
         private bool _drawerShowIconsWhenHidden;
@@ -1238,62 +1238,5 @@ namespace MaterialSkin.Controls
         [DllImport("user32.dll")]
         private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
         #endregion
-    }
-
-    public class MessageFilter : IMessageFilter
-    {
-        private const int WM_MOUSEWHEEL = 0x020A;
-        private const int WM_MOUSEHWHEEL = 0x020E;
-
-        [DllImport("user32.dll")]
-        static extern IntPtr WindowFromPoint(Point p);
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, IntPtr lParam);
-
-        public bool PreFilterMessage(ref Message m)
-        {
-            switch (m.Msg)
-            {
-                case WM_MOUSEWHEEL:
-                case WM_MOUSEHWHEEL:
-                    IntPtr hControlUnderMouse = WindowFromPoint(new Point((int)m.LParam));
-                    if (hControlUnderMouse == m.HWnd)
-                    {
-                        //Do nothing because it's already headed for the right control
-                        return false;
-                    }
-                    else
-                    {
-                        //Send the scroll message to the control under the mouse
-                        uint u = Convert.ToUInt32(m.Msg);
-                        SendMessage(hControlUnderMouse, u, m.WParam, m.LParam);
-                        return true;
-                    }
-                default:
-                    return false;
-            }
-        }
-    }
-
-    public partial class MaterialDrawerForm : Form
-    {
-        MessageFilter mf = null;
-
-        public MaterialDrawerForm()
-        {
-            Load += MyForm_Load;
-            FormClosing += MyForm_FormClosing;
-        }
-
-        private void MyForm_Load(object sender, EventArgs e)
-        {
-            mf = new MessageFilter();
-            Application.AddMessageFilter(mf);
-        }
-
-        private void MyForm_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            Application.RemoveMessageFilter(mf);
-        }
     }
 }

--- a/MaterialSkin/MaterialSkin.csproj
+++ b/MaterialSkin/MaterialSkin.csproj
@@ -141,6 +141,7 @@
     <Compile Include="MaterialItemCollection.cs" />
     <Compile Include="MaterialItemCollectionEditor.cs" />
     <Compile Include="MaterialSkinManager.cs" />
+    <Compile Include="MouseWheelRedirector.cs" />
     <Compile Include="NativeTextRenderer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/MaterialSkin/MouseWheelRedirector.cs
+++ b/MaterialSkin/MouseWheelRedirector.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualBasic;
+using System.Windows.Forms;
+using System.Runtime.InteropServices;
+
+public class MouseWheelRedirector : IMessageFilter
+{
+    private static MouseWheelRedirector instance = null;
+    private static bool _active = false;
+
+    public static bool Active
+    {
+        set
+        {
+            if (_active != value)
+            {
+                _active = value;
+                if (_active)
+                {
+                    if (instance == null)
+                        instance = new MouseWheelRedirector();
+                    Application.AddMessageFilter(instance);
+                }
+                else if (instance != null)
+                    Application.RemoveMessageFilter(instance);
+            }
+        }
+        get
+        {
+            return _active;
+        }
+    }
+
+    public static void Attach(Control control)
+    {
+        if (!_active)
+            Active = true;
+        control.MouseEnter += instance.ControlMouseEnter;
+        control.MouseLeave += instance.ControlMouseLeaveOrDisposed;
+        control.Disposed += instance.ControlMouseLeaveOrDisposed;
+    }
+
+    public static void Detach(Control control)
+    {
+        if (instance == null)
+            return;
+        control.MouseEnter -= instance.ControlMouseEnter;
+        control.MouseLeave -= instance.ControlMouseLeaveOrDisposed;
+        control.Disposed -= instance.ControlMouseLeaveOrDisposed;
+        if (instance.currentControl == control)
+            instance.currentControl = null;
+    }
+
+    public MouseWheelRedirector()
+    {
+    }
+
+    private Control currentControl;
+
+    private void ControlMouseEnter(object sender, System.EventArgs e)
+    {
+        var control = (Control)sender;
+        if (!control.Focused)
+            currentControl = control;
+        else
+            currentControl = null;
+    }
+
+    private void ControlMouseLeaveOrDisposed(object sender, System.EventArgs e)
+    {
+        if (currentControl == sender)
+            currentControl = null;
+    }
+
+    private const int WM_MOUSEWHEEL = 0x20A;
+    public bool PreFilterMessage(ref System.Windows.Forms.Message m)
+    {
+        if (currentControl != null && m.Msg == WM_MOUSEWHEEL)
+        {
+            SendMessage(currentControl.Handle, m.Msg, m.WParam, m.LParam);
+            return true;
+        }
+        else
+            return false;
+    }
+
+    [DllImport("user32.dll", SetLastError = false)]
+    private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+}


### PR DESCRIPTION
This is based on #236  which is based on #163 . #236 is better coded, as long as it will increments/decrements the `Height` of the drawer (the right divider is higher enough, will not stops when scrolling up, in #163 the divider was shorter and it was shorter when scrolling up).
I removed the `EnableScrolling` property from `MaterialDrawer` control, as long as we need this option all the time. Scrolling option does not affect Drawer as long as its content is not higher than itself.

BTW: Reading Material Design implementation, about showing ScrollBar, (as you @orapps44 asked for in your comment in #236 ) `NavigationDrawer` does not shows any scrollbar when scrolls or when mouse hover. This is the implementation of [Material Design scrolling techniques](https://material.io/archive/guidelines/patterns/scrolling-techniques.html#scrolling-techniques-behavior). It just scrolls container if childs are in the non visible area of control.

Using this technique we can go forward and implement Drawer SubMenu items, as @ryanrox asked for it in #177 or in the latest #293

Demo:
![ScrollableDrawer](https://user-images.githubusercontent.com/49796453/141988294-0bed9a55-9749-46c6-a833-8aff14708a57.gif)
