### PR TITLE
Set default TabPage BackColor

### DIFF
--- a/MaterialSkin/Controls/MaterialTabControl.cs
+++ b/MaterialSkin/Controls/MaterialTabControl.cs
@@ -25,5 +25,12 @@
             if (m.Msg == 0x1328 && !DesignMode) m.Result = (IntPtr)1;
             else base.WndProc(ref m);
         }
+        
+        protected override void OnControlAdded(ControlEventArgs e)
+        {
+            base.OnControlAdded(e);
+
+            e.Control.BackColor = System.Drawing.Color.White;
+        }
     }
 }


### PR DESCRIPTION
Set default TabPage BackColor to white color to avoid control background issue with designer (issue appears when background is set to transparent).