### PR TITLE
Enhancement (compatibility with Msft CLI/C++) + Code Cleansing and Refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+
+
+This repo is a fork obtained from https://github.com/leocb/MaterialSkin.git
+  - Revision: e14384f49f142cde712951824f6c461b57a0032b
+  - Author: orapps44 <77468294+orapps44@users.noreply.github.com>
+  - Date: 06/02/2022 21:50:11
+
+
+
+build 2.3.1.3 [2022-02-20] 
+-------------------------
+  - Code Cleansing:
+    - moved all p/invoke declarations to a new static class "NativeWin" (NativeWin.cs)
+      - there were a significant number of duplicated declarations on several controls
+      - affected files:
+        - NativeTextRenderer.cs
+        - MouseWheelRedirector.cs
+        - MaterialDialog.cs
+        - MaterialForm.cs
+        - MaterialMultiLineTextBox.cs
+        - MaterialMultiLineTextBox2.cs
+        - MaterialScrollBar.cs
+        - MaterialSnackBar.cs
+        - MaterialTextBox.cs
+        - MaterialSkinManager.cs
+
+    - moved several const declarations related to native Window Message IDs to new static class "NativeWin"
+      - affected files:
+        - MouseWheelRedirector.cs
+
+    - moved all possible category's labels to a new static class "CategoryLabels" (Globals.cs) and replaced the Category Labels by the corresponding const string
+      - affected files:
+        - MaterialButton.cs
+        - MaterialCheckBox.cs
+        - MaterialComboBox.cs
+        - MaterialDrawer.cs
+        - MaterialExpansionPanel.cs
+        - MaterialFloatingActionButton.cs
+        - MaterialForm.cs
+        - MaterialLabel.cs
+        - MaterialListBox.cs
+        - MaterialListView.cs
+        - MaterialMaskedTextBox.cs
+        - MaterialMultiLineTextBox.cs
+        - MaterialMultiLineTextBox2.cs
+        - MaterialRadioButton.cs
+        - MaterialScrollBar.cs
+        - MaterialSlider.cs
+        - MaterialSnackBar.cs
+        - MaterialSwitch.cs
+        - MaterialTabSelector.cs
+        - MaterialTextBox.cs
+        - MaterialTextBox2.cs
+
+    - moved several const declarations and enum declarations that were shared among files to a new file Globals.cs
+        - MaterialDrawer.cs
+
+  - Enhancement - compatibility with Msft CLI/C++:
+    - enum value MouseState.OUT (IMaterialControl.cs) renamed to MouseState.OUT_
+      - "OUT" keyword is a reserved word on CLI/C++.

--- a/MaterialSkin.sln
+++ b/MaterialSkin.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.136
@@ -9,6 +8,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaterialSkin", "MaterialSki
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{17028688-3699-4BC7-849F-A6B0F6E766BC}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/MaterialSkin/Controls/MaterialButton.cs
+++ b/MaterialSkin/Controls/MaterialButton.cs
@@ -24,7 +24,7 @@
 
         // icons
         private TextureBrush iconsBrushes;
-        
+
         /// <summary>
         /// Gets or sets the Depth
         /// </summary>
@@ -59,14 +59,14 @@
         [Browsable(false)]
         public Color NoAccentTextColor { get; set; }
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         public bool UseAccentColor
         {
             get { return useAccentColor; }
             set { useAccentColor = value; Invalidate(); }
         }
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         /// <summary>
         /// Gets or sets a value indicating whether HighEmphasis
         /// </summary>
@@ -77,7 +77,7 @@
         }
 
         [DefaultValue(true)]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Draw Shadows around control")]
         public bool DrawShadows
         {
@@ -85,24 +85,24 @@
             set { drawShadows = value; Invalidate(); }
         }
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         public MaterialButtonType Type
         {
             get { return type; }
             set { type = value; preProcessIcons(); Invalidate(); }
         }
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         /// <summary>
         /// Gets or sets a value indicating button density
         /// </summary>
         public MaterialButtonDensity Density
         {
             get { return _density; }
-            set 
-            { 
+            set
+            {
                 _density = value;
-                if (_density== MaterialButtonDensity.Dense)
+                if (_density == MaterialButtonDensity.Dense)
                     Size = new Size(Size.Width, HEIGHTDENSE);
                 else
                     Size = new Size(Size.Width, HEIGHTDEFAULT);
@@ -119,7 +119,7 @@
         }
 
         public CharacterCasingEnum _cc;
-        [Category("Behavior"), DefaultValue(CharacterCasingEnum.Upper), Description("Change capitalization of Text property")]
+        [Category(CategoryLabels.Behavior), DefaultValue(CharacterCasingEnum.Upper), Description("Change capitalization of Text property")]
         public CharacterCasingEnum CharacterCasing
         {
             get => _cc;
@@ -200,7 +200,7 @@
         private MaterialButtonType type;
         private MaterialButtonDensity _density;
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         /// <summary>
         /// Gets or sets the Icon
         /// </summary>
@@ -325,7 +325,7 @@
 
             int newWidth, newHeight;
             //Resize icon if greater than ICON_SIZE
-            if (Icon.Width> ICON_SIZE || Icon.Height > ICON_SIZE)
+            if (Icon.Width > ICON_SIZE || Icon.Height > ICON_SIZE)
             {
                 //calculate aspect ratio
                 float aspect = Icon.Width / (float)Icon.Height;
@@ -399,7 +399,7 @@
             textureBrushGray.WrapMode = System.Drawing.Drawing2D.WrapMode.Clamp;
 
             // Translate the brushes to the correct positions
-            var iconRect = new Rectangle(8, (Height/2 - ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
+            var iconRect = new Rectangle(8, (Height / 2 - ICON_SIZE / 2), ICON_SIZE, ICON_SIZE);
 
             textureBrushGray.TranslateTransform(iconRect.X + iconRect.Width / 2 - IconResized.Width / 2,
                                                 iconRect.Y + iconRect.Height / 2 - IconResized.Height / 2);
@@ -534,7 +534,7 @@
 
             Color textColor = Enabled ? (HighEmphasis ? (Type == MaterialButtonType.Text || Type == MaterialButtonType.Outlined) ?
                 UseAccentColor ? SkinManager.ColorScheme.AccentColor : // Outline or Text and accent and emphasis
-                NoAccentTextColor == Color.Empty ? 
+                NoAccentTextColor == Color.Empty ?
                 SkinManager.ColorScheme.PrimaryColor :  // Outline or Text and emphasis
                 NoAccentTextColor : // User defined Outline or Text and emphasis
                 SkinManager.ColorScheme.TextColor : // Contained and Emphasis
@@ -607,7 +607,7 @@
                 s.Width += extra;
                 s.Height = HEIGHTDEFAULT;
             }
-            if (Icon != null && Text.Length==0 && s.Width < MINIMUMWIDTHICONONLY) s.Width = MINIMUMWIDTHICONONLY;
+            if (Icon != null && Text.Length == 0 && s.Width < MINIMUMWIDTHICONONLY) s.Width = MINIMUMWIDTHICONONLY;
             else if (s.Width < MINIMUMWIDTH) s.Width = MINIMUMWIDTH;
 
             return s;
@@ -627,7 +627,7 @@
                 return;
             }
 
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
             MouseEnter += (sender, args) =>
             {
                 MouseState = MouseState.HOVER;
@@ -636,7 +636,7 @@
             };
             MouseLeave += (sender, args) =>
             {
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 _hoverAnimationManager.StartNewAnimation(AnimationDirection.Out);
                 Invalidate();
             };
@@ -664,7 +664,7 @@
             };
             LostFocus += (sender, args) =>
             {
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 _focusAnimationManager.StartNewAnimation(AnimationDirection.Out);
                 Invalidate();
             };

--- a/MaterialSkin/Controls/MaterialCheckBox.cs
+++ b/MaterialSkin/Controls/MaterialCheckBox.cs
@@ -25,7 +25,7 @@
 
         private bool _ripple;
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public bool Ripple
         {
             get { return _ripple; }
@@ -224,7 +224,7 @@
 
             if (DesignMode) return;
 
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
             GotFocus += (sender, AddingNewEventArgs) =>
             {
@@ -258,7 +258,7 @@
             MouseLeave += (sender, args) =>
             {
                 MouseLocation = new Point(-1, -1);
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 //if (Ripple && hovered)
                 //{
                 //    _hoverAM.StartNewAnimation(AnimationDirection.Out, new object[] { Checked });

--- a/MaterialSkin/Controls/MaterialComboBox.cs
+++ b/MaterialSkin/Controls/MaterialComboBox.cs
@@ -11,7 +11,7 @@
     public class MaterialComboBox : ComboBox, IMaterialControl
     {
         // For some reason, even when overriding the AutoSize property, it doesn't appear on the properties panel, so we have to create a new one.
-        [Browsable(true), EditorBrowsable(EditorBrowsableState.Always), Category("Layout")]
+        [Browsable(true), EditorBrowsable(EditorBrowsableState.Always), Category(CategoryLabels.Layout)]
         private bool _AutoResize;
 
         public bool AutoResize
@@ -36,7 +36,7 @@
 
         private bool _UseTallSize;
 
-        [Category("Material Skin"), DefaultValue(true), Description("Using a larger size enables the hint to always be visible")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true), Description("Using a taller size enables the hint to always be visible")]
         public bool UseTallSize
         {
             get { return _UseTallSize; }
@@ -48,12 +48,12 @@
             }
         }
 
-        [Category("Material Skin"), DefaultValue(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true)]
         public bool UseAccent { get; set; }
 
         private string _hint = string.Empty;
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true)]
         public string Hint
         {
             get { return _hint; }
@@ -120,12 +120,12 @@
             _animationManager.OnAnimationFinished += sender => _animationManager.SetProgress(0);
             DropDownClosed += (sender, args) =>
             {
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 if (SelectedIndex < 0 && !Focused) _animationManager.StartNewAnimation(AnimationDirection.Out);
             };
             LostFocus += (sender, args) =>
             {
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 if (SelectedIndex < 0) _animationManager.StartNewAnimation(AnimationDirection.Out);
             };
             DropDown += (sender, args) =>
@@ -144,7 +144,7 @@
             };
             MouseLeave += (sender, args) =>
             {
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 Invalidate();
             };
         }
@@ -263,7 +263,7 @@
                     NativeText.DrawTransparentText(
                     Hint,
                     SkinManager.getTextBoxFontBySize(hintTextSize),
-                    Enabled ? DroppedDown || Focused ? 
+                    Enabled ? DroppedDown || Focused ?
                     SelectedColor : // Focus 
                     SkinManager.TextMediumEmphasisColor : // not focused
                     SkinManager.TextDisabledOrHintColor, // Disabled
@@ -293,7 +293,7 @@
             {
                 g.FillRectangle(SkinManager.BackgroundHoverBrush, e.Bounds);
             }
-            
+
             string Text = "";
             if (!string.IsNullOrWhiteSpace(DisplayMember))
             {
@@ -328,7 +328,7 @@
         protected override void OnCreateControl()
         {
             base.OnCreateControl();
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
             MeasureItem += CustomMeasureItem;
             DrawItem += CustomDrawItem;
             DropDownStyle = ComboBoxStyle.DropDownList;

--- a/MaterialSkin/Controls/MaterialDialog.cs
+++ b/MaterialSkin/Controls/MaterialDialog.cs
@@ -31,16 +31,6 @@
         /// </summary>
         //public ObservableCollection<MaterialButton> Buttons { get; set; }
 
-        [DllImport("Gdi32.dll", EntryPoint = "CreateRoundRectRgn")]
-        private static extern IntPtr CreateRoundRectRgn
-        (
-            int nLeftRect,     // x-coordinate of upper-left corner
-            int nTopRect,      // y-coordinate of upper-left corner
-            int nRightRect,    // x-coordinate of lower-right corner
-            int nBottomRect,   // y-coordinate of lower-right corner
-            int nWidthEllipse, // width of ellipse
-            int nHeightEllipse // height of ellipse
-        );
 
         /// <summary>
         /// Constructer Setting up the Layout
@@ -122,7 +112,7 @@
                 RectHeight + 9);
 
             Height = _header_Height + TEXT_TOP_PADDING + textRect.Height + TEXT_BOTTOM_PADDING + 52; //560;
-            Region = System.Drawing.Region.FromHrgn(CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
+            Region = System.Drawing.Region.FromHrgn(NativeWin.CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
 
             int _buttonWidth = ((TextRenderer.MeasureText(ValidationButtonText, SkinManager.getFontByType(MaterialSkinManager.fontType.Button))).Width + 32);
             Rectangle _validationbuttonBounds = new Rectangle((Width) - BUTTON_PADDING - _buttonWidth, Height - BUTTON_PADDING - BUTTON_HEIGHT, _buttonWidth, BUTTON_HEIGHT);
@@ -169,7 +159,7 @@
         {
         }
 
-       public MaterialDialog(Form ParentForm, string Title, string Text, string ValidationButtonText, bool ShowCancelButton, string CancelButtonText) : this(ParentForm, Title, Text, ValidationButtonText, ShowCancelButton, CancelButtonText, false)
+        public MaterialDialog(Form ParentForm, string Title, string Text, string ValidationButtonText, bool ShowCancelButton, string CancelButtonText) : this(ParentForm, Title, Text, ValidationButtonText, ShowCancelButton, CancelButtonText, false)
         {
         }
 
@@ -181,7 +171,7 @@
         {
             base.OnLoad(e);
 
-            Location = new Point(Convert.ToInt32(Owner.Location.X + (Owner.Width / 2) - (Width / 2)), Convert.ToInt32(Owner.Location.Y + (Owner.Height/2) - (Height / 2)));
+            Location = new Point(Convert.ToInt32(Owner.Location.X + (Owner.Width / 2) - (Width / 2)), Convert.ToInt32(Owner.Location.Y + (Owner.Height / 2) - (Height / 2)));
             _AnimationManager.StartNewAnimation(AnimationDirection.In);
         }
 
@@ -207,12 +197,12 @@
 
             e.Graphics.Clear(BackColor);
 
-            
+
             // Calc title Rect
             Rectangle titleRect = new Rectangle(
                 LEFT_RIGHT_PADDING,
                 0,
-                Width - (2 * LEFT_RIGHT_PADDING) ,
+                Width - (2 * LEFT_RIGHT_PADDING),
                 _header_Height);
 
             //Draw title
@@ -236,9 +226,9 @@
 
             Rectangle textRect = new Rectangle(
                 LEFT_RIGHT_PADDING,
-                _header_Height+17,
+                _header_Height + 17,
                 RectWidth,
-                RectHeight +19);
+                RectHeight + 19);
 
             //Draw  Text
             using (NativeTextRenderer NativeText = new NativeTextRenderer(g))

--- a/MaterialSkin/Controls/MaterialDrawer.cs
+++ b/MaterialSkin/Controls/MaterialDrawer.cs
@@ -16,7 +16,7 @@
 
         private bool _showIconsWhenHidden;
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool ShowIconsWhenHidden
         {
             get
@@ -39,7 +39,7 @@
 
         private bool _isOpen;
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool IsOpen
         {
             get
@@ -56,13 +56,13 @@
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool AutoHide { get; set; }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool AutoShow { get; set; }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         private bool _useColors;
 
         public bool UseColors
@@ -79,7 +79,7 @@
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         private bool _highlightWithAccent;
 
         public bool HighlightWithAccent
@@ -96,7 +96,7 @@
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         private bool _backgroundWithAccent;
 
         public bool BackgroundWithAccent
@@ -112,7 +112,7 @@
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public int IndicatorWidth { get; set; }
 
         [Browsable(false)]
@@ -151,7 +151,7 @@
 
         private MaterialTabControl _baseTabControl;
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public MaterialTabControl BaseTabControl
         {
             get { return _baseTabControl; }
@@ -302,7 +302,7 @@
         private List<Rectangle> _drawerItemRects;
         private List<GraphicsPath> _drawerItemPaths;
 
-        private const int TAB_HEADER_PADDING = 24;
+
         private const int BORDER_WIDTH = 7;
 
         private int drawerItemHeight;
@@ -392,7 +392,7 @@
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected override void InitLayout()
         {
-            drawerItemHeight = TAB_HEADER_PADDING * 2 - SkinManager.FORM_PADDING / 2;
+            drawerItemHeight = Globals.TAB_HEADER_PADDING * 2 - SkinManager.FORM_PADDING / 2;
             MinWidth = (int)(SkinManager.FORM_PADDING * 1.5 + drawerItemHeight);
             _showHideAnimManager.SetProgress(_isOpen ? 0 : 1);
             showHideAnimation();
@@ -653,18 +653,18 @@
             base.OnMouseUp(e);
             if (DesignMode)
                 return;
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
         }
 
         protected override void OnMouseMove(MouseEventArgs e)
         {
             if (DesignMode)
                 return;
-            
+
             if (e.Button == MouseButtons.Left && e.Y != _lastMouseY && (Location.Y < 0 || Height < (8 + drawerItemHeight) * _drawerItemRects.Count))
             {
                 int diff = e.Y - _lastMouseY;
-                if (diff > 0) 
+                if (diff > 0)
                 {
                     if (Location.Y < 0)
                     {
@@ -672,7 +672,7 @@
                         Height = Parent.Height + Math.Abs(Location.Y);
                     }
                 }
-                else 
+                else
                 {
                     if (Height < (8 + drawerItemHeight) * _drawerItemRects.Count)
                     {
@@ -682,12 +682,12 @@
                 }
                 //return;
             }
-            
+
             base.OnMouseMove(e);
 
             if (_drawerItemRects == null)
                 UpdateTabRects();
-                
+
             Cursor previousCursor = Cursor;
 
             if (e.Location.X + this.Location.X < BORDER_WIDTH)
@@ -716,7 +716,7 @@
         protected override void OnMouseEnter(EventArgs e)
         {
             base.OnMouseEnter(e);
-            if (AutoShow && _isOpen==false)
+            if (AutoShow && _isOpen == false)
             {
                 Show();
             }
@@ -766,7 +766,7 @@
             {
                 _drawerItemRects[i] = (new Rectangle(
                     (int)(SkinManager.FORM_PADDING * 0.75) - (ShowIconsWhenHidden ? Location.X : 0),
-                    (TAB_HEADER_PADDING * 2) * i + (int)(SkinManager.FORM_PADDING >> 1),
+            (Globals.TAB_HEADER_PADDING * 2) * i + (int)(SkinManager.FORM_PADDING >> 1),
                     (Width + (ShowIconsWhenHidden ? Location.X : 0)) - (int)(SkinManager.FORM_PADDING * 1.5) - 1,
                     drawerItemHeight));
 

--- a/MaterialSkin/Controls/MaterialExpansionPanel.cs
+++ b/MaterialSkin/Controls/MaterialExpansionPanel.cs
@@ -29,20 +29,20 @@ namespace MaterialSkin.Controls
         private const int _footerHeight = 68;
         private const int _footerButtonHeight = 36;
         private const int _minHeight = 200;
-        private int _headerHeight ;
+        private int _headerHeight;
 
-        private bool _collapse ;
+        private bool _collapse;
         private bool _useAccentColor;
         private int _expandHeight;
-									
-									  
+
+
         private string _titleHeader;
         private string _descriptionHeader;
         private string _validationButtonText;
         private string _cancelButtonText;
-										
-																 
-										  
+
+
+
         private bool _showValidationButtons;
         private bool _showCollapseExpand;
         private bool _drawShadows;
@@ -77,7 +77,7 @@ namespace MaterialSkin.Controls
         [Browsable(false)]
         public MouseState MouseState { get; set; }
 
-        [Category("Material Skin"), DefaultValue(false), DisplayName("Use Accent Color")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), DisplayName("Use Accent Color")]
         public bool UseAccentColor
         {
             get { return _useAccentColor; }
@@ -86,7 +86,7 @@ namespace MaterialSkin.Controls
 
         [DefaultValue(false)]
         [Description("Collapses the control when set to true")]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         public bool Collapse
         {
             get { return _collapse; }
@@ -99,7 +99,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue("Title")]
-        [Category("Material Skin"), DisplayName("Title")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Title")]
         [Description("Title to show in expansion panel's header")]
         public string Title
         {
@@ -112,7 +112,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue("Description")]
-        [Category("Material Skin"), DisplayName("Description")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Description")]
         [Description("Description to show in expansion panel's header")]
         public string Description
         {
@@ -125,7 +125,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue(true)]
-        [Category("Material Skin"), DisplayName("Draw Shadows")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Draw Shadows")]
         [Description("Draw Shadows around control")]
         public bool DrawShadows
         {
@@ -134,7 +134,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue(240)]
-        [Category("Material Skin"), DisplayName("Expand Height")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Expand Height")]
         [Description("Define control height when expanded")]
         public int ExpandHeight
         {
@@ -143,7 +143,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue(true)]
-        [Category("Material Skin"), DisplayName("Show collapse/expand")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Show collapse/expand")]
         [Description("Show collapse/expand indicator")]
         public bool ShowCollapseExpand
         {
@@ -152,7 +152,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue(true)]
-        [Category("Material Skin"), DisplayName("Show validation buttons")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Show validation buttons")]
         [Description("Show save/cancel button")]
         public bool ShowValidationButtons
         {
@@ -161,7 +161,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue("SAVE")]
-        [Category("Material Skin"), DisplayName("Validation button text")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Validation button text")]
         [Description("Set Validation button text")]
         public string ValidationButtonText
         {
@@ -170,7 +170,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue("CANCEL")]
-        [Category("Material Skin"), DisplayName("Cancel button text")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Cancel button text")]
         [Description("Set Cancel button text")]
         public string CancelButtonText
         {
@@ -179,7 +179,7 @@ namespace MaterialSkin.Controls
         }
 
         [DefaultValue(false)]
-        [Category("Material Skin"), DisplayName("Validation button enable")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Validation button enable")]
         [Description("Enable validation button")]
         public bool ValidationButtonEnable
         {
@@ -193,19 +193,19 @@ namespace MaterialSkin.Controls
 
         #region "Events"
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Save button is clicked")]
         public event EventHandler SaveClick;
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Cancel button is clicked")]
         public event EventHandler CancelClick;
 
-        [Category("Disposition")]
+        [Category(CategoryLabels.Disposition)]
         [Description("Fires when Panel Collapse")]
         public event EventHandler PanelCollapse;
 
-        [Category("Disposition")]
+        [Category(CategoryLabels.Disposition)]
         [Description("Fires when Panel Expand")]
         public event EventHandler PanelExpand;
 
@@ -231,9 +231,9 @@ namespace MaterialSkin.Controls
             ForeColor = SkinManager.TextHighEmphasisColor;
 
             Padding = new Padding(24, 64, 24, 16);
-            Margin = new Padding( 3, 16,  3, 16);
+            Margin = new Padding(3, 16, 3, 16);
             Size = new Size(480, ExpandHeight);
-            							 
+
             //CollapseOrExpand();
 
             _validationButton = new MaterialButton
@@ -254,18 +254,18 @@ namespace MaterialSkin.Controls
                 Text = "CANCEL"
             };
 
-            if (!Controls.Contains(_validationButton) )
+            if (!Controls.Contains(_validationButton))
             {
                 Controls.Add(_validationButton);
             }
-           if (!Controls.Contains(_cancelButton) )
+            if (!Controls.Contains(_cancelButton))
             {
                 Controls.Add(_cancelButton);
             }
 
             _validationButton.Click += _validationButton_Click;
             _cancelButton.Click += _cancelButton_Click;
-	    
+
             UpdateRects();
         }
 
@@ -383,7 +383,7 @@ namespace MaterialSkin.Controls
             UpdateRects();
 
             if (Parent != null)
-            { 
+            {
                 RemoveShadowPaintEvent(Parent, drawShadowOnParent);
                 AddShadowPaintEvent(Parent, drawShadowOnParent);
             }
@@ -435,7 +435,7 @@ namespace MaterialSkin.Controls
                     return;
             }
 
-             base.OnMouseDown(e);
+            base.OnMouseDown(e);
         }
 
         protected override void OnMouseLeave(EventArgs e)
@@ -484,7 +484,7 @@ namespace MaterialSkin.Controls
                     expansionPanelBorderRectF.X -= 0.5f;
                     expansionPanelBorderRectF.Y -= 0.5f;
                     GraphicsPath expansionPanelBoarderPath = DrawHelper.CreateRoundRect(expansionPanelBorderRectF, 2);
-																					   
+
                     g.FillPath(SkinManager.ExpansionPanelFocusBrush, expansionPanelBoarderPath);
                 }
                 else
@@ -517,13 +517,13 @@ namespace MaterialSkin.Controls
             }
 
             if (!String.IsNullOrEmpty(_descriptionHeader))
-	    {
+            {
                 //Draw description header text 
 
                 Rectangle headerDescriptionRect = new Rectangle(
                     headerRect.Right + _expansionPanelDefaultPadding,
                     (_headerHeight - _textHeaderHeight) / 2,
-                    _expandcollapseBounds.Left - (headerRect.Right + _expansionPanelDefaultPadding ) - _expansionPanelDefaultPadding,
+                    _expandcollapseBounds.Left - (headerRect.Right + _expansionPanelDefaultPadding) - _expansionPanelDefaultPadding,
                     _textHeaderHeight);
 
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
@@ -539,7 +539,7 @@ namespace MaterialSkin.Controls
                 }
             }
 
-            if (_showCollapseExpand==true)
+            if (_showCollapseExpand == true)
             {
                 using (var formButtonsPen = new Pen(_useAccentColor && Enabled ? SkinManager.ColorScheme.AccentColor : SkinManager.TextDisabledOrHintColor, 2))
                 {

--- a/MaterialSkin/Controls/MaterialFloatingActionButton.cs
+++ b/MaterialSkin/Controls/MaterialFloatingActionButton.cs
@@ -27,12 +27,12 @@
         private Boolean _mouseHover = false;
 
         [DefaultValue(true)]
-        [Category("Material Skin"), DisplayName("Draw Shadows")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Draw Shadows")]
         [Description("Draw Shadows around control")]
         public bool DrawShadows { get; set; }
 
         [DefaultValue(false)]
-        [Category("Material Skin"), DisplayName("Size Mini")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Size Mini")]
         [Description("Set control size to default or mini")]
         public bool Mini
         {
@@ -45,10 +45,10 @@
             }
         }
 
-        private bool _mini ;
+        private bool _mini;
 
         [DefaultValue(false)]
-        [Category("Material Skin"), DisplayName("Animate Show HideButton")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Animate Show HideButton")]
         public bool AnimateShowHideButton
         {
             get { return _animateShowButton; }
@@ -58,7 +58,7 @@
         private bool _animateShowButton;
 
         [DefaultValue(false)]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Define icon to display")]
         public Image Icon
         {
@@ -187,10 +187,10 @@
             DrawHelper.DrawRoundShadow(g, fabBounds);
 
             // draw fab
-            g.FillEllipse(Enabled ? _mouseHover ? 
-                new SolidBrush(SkinManager.ColorScheme.AccentColor.Lighten(0.25f)) : 
+            g.FillEllipse(Enabled ? _mouseHover ?
+                new SolidBrush(SkinManager.ColorScheme.AccentColor.Lighten(0.25f)) :
                 SkinManager.ColorScheme.AccentBrush :
-                new SolidBrush(DrawHelper.BlendColor(SkinManager.ColorScheme.AccentColor, SkinManager.SwitchOffDisabledThumbColor, 197)), 
+                new SolidBrush(DrawHelper.BlendColor(SkinManager.ColorScheme.AccentColor, SkinManager.SwitchOffDisabledThumbColor, 197)),
                 fabBounds);
 
             if (_animationManager.IsAnimating())
@@ -263,7 +263,7 @@
 
         protected override void OnResize(EventArgs e)
         {
-             base.OnResize(e);
+            base.OnResize(e);
 
             if (DrawShadows && Parent != null)
             {

--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -9,9 +9,9 @@ namespace MaterialSkin.Controls
     using System.Runtime.InteropServices;
     using System.Windows.Forms;
 
-    #if NETFRAMEWORK
+#if NETFRAMEWORK
     using System.Runtime.Remoting.Channels;
-    #endif
+#endif
 
     public class MaterialForm : Form, IMaterialControl
     {
@@ -25,10 +25,10 @@ namespace MaterialSkin.Controls
         [Browsable(false)]
         public MouseState MouseState { get; set; }
 
-        [Category("Layout")]
+        [Category(CategoryLabels.Layout)]
         public bool Sizable { get; set; }
 
-        [Category("Material Skin"), Browsable(true), DisplayName("Form Style"), DefaultValue(FormStyles.ActionBar_40)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), DisplayName("Form Style"), DefaultValue(FormStyles.ActionBar_40)]
         public FormStyles FormStyle
         {
             get => _formStyle;
@@ -41,7 +41,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool DrawerShowIconsWhenHidden
         {
             get => _drawerShowIconsWhenHidden;
@@ -58,27 +58,27 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public int DrawerWidth { get; set; }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool DrawerAutoHide
         {
             get => _drawerAutoHide;
             set => drawerControl.AutoHide = _drawerAutoHide = value;
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool DrawerAutoShow
         {
             get => _drawerAutoShow;
             set => drawerControl.AutoShow = _drawerAutoShow = value;
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public int DrawerIndicatorWidth { get; set; }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool DrawerIsOpen
         {
             get => _drawerIsOpen;
@@ -95,7 +95,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool DrawerUseColors
         {
             get => _drawerUseColors;
@@ -112,7 +112,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool DrawerHighlightWithAccent
         {
             get => _drawerHighlightWithAccent;
@@ -129,7 +129,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public bool DrawerBackgroundWithAccent
         {
             get => _backgroundWithAccent;
@@ -146,7 +146,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Drawer")]
+        [Category(CategoryLabels.Drawer)]
         public MaterialTabControl DrawerTabControl { get; set; }
 
         public override string Text
@@ -222,133 +222,7 @@ namespace MaterialSkin.Controls
             None
         }
 
-        /// <summary>
-        /// Window Messages
-        /// <see href="https://docs.microsoft.com/en-us/windows/win32/winmsg/about-messages-and-message-queues"/>
-        /// </summary>
-        private enum WM
-        {
-            /// <summary>
-            /// WM_NCCALCSIZE
-            /// </summary>
-            NonClientCalcSize = 0x0083,
-            /// <summary>
-            /// WM_NCACTIVATE
-            /// </summary>
-            NonClientActivate = 0x0086,
-            /// <summary>
-            /// WM_NCLBUTTONDOWN
-            /// </summary>
-            NonClientLeftButtonDown = 0x00A1,
-            /// <summary>
-            /// WM_SYSCOMMAND
-            /// </summary>
-            SystemCommand = 0x0112,
-            /// <summary>
-            /// WM_MOUSEMOVE
-            /// </summary>
-            MouseMove = 0x0200,
-            /// <summary>
-            /// WM_LBUTTONDOWN
-            /// </summary>
-            LeftButtonDown = 0x0201,
-            /// <summary>
-            /// WM_LBUTTONUP
-            /// </summary>
-            LeftButtonUp = 0x0202,
-            /// <summary>
-            /// WM_LBUTTONDBLCLK
-            /// </summary>
-            LeftButtonDoubleClick = 0x0203,
-            /// <summary>
-            /// WM_RBUTTONDOWN
-            /// </summary>
-            RightButtonDown = 0x0204,
-        }
 
-        /// <summary>
-        /// Hit Test Results
-        /// <see href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-nchittest"/>
-        /// </summary>
-        private enum HT
-        {
-            /// <summary>
-            /// HTNOWHERE - Nothing under cursor
-            /// </summary>
-            None = 0,
-            /// <summary>
-            /// HTCAPTION - Titlebar
-            /// </summary>
-            Caption = 2,
-            /// <summary>
-            /// HTLEFT - Left border
-            /// </summary>
-            Left = 10,
-            /// <summary>
-            /// HTRIGHT - Right border
-            /// </summary>
-            Right = 11,
-            /// <summary>
-            /// HTTOP - Top border
-            /// </summary>
-            Top = 12,
-            /// <summary>
-            /// HTTOPLEFT - Top left corner
-            /// </summary>
-            TopLeft = 13,
-            /// <summary>
-            /// HTTOPRIGHT - Top right corner
-            /// </summary>
-            TopRight = 14,
-            /// <summary>
-            /// HTBOTTOM - Bottom border
-            /// </summary>
-            Bottom = 15,
-            /// <summary>
-            /// HTBOTTOMLEFT - Bottom left corner
-            /// </summary>
-            BottomLeft = 16,
-            /// <summary>
-            /// HTBOTTOMRIGHT - Bottom right corner
-            /// </summary>
-            BottomRight = 17,
-        }
-
-        /// <summary>
-        /// Window Styles
-        /// <see href="https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles"/>
-        /// </summary>
-        private enum WS
-        {
-            /// <summary>
-            /// WS_MINIMIZEBOX - Allow minimizing from taskbar
-            /// </summary>
-            MinimizeBox = 0x20000,
-            /// <summary>
-            /// WS_SIZEFRAME - Required for Aero Snapping
-            /// </summary>
-            SizeFrame = 0x40000,
-            /// <summary>
-            /// WS_SYSMENU - Trigger the creation of the system menu
-            /// </summary>
-            SysMenu = 0x80000,
-        }
-
-        /// <summary>
-        /// Track Popup Menu Flags
-        /// <see href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-trackpopupmenu"/>
-        /// </summary>
-        private enum TPM
-        {
-            /// <summary>
-            /// TPM_LEFTALIGN
-            /// </summary>
-            LeftAlign = 0x0000,
-            /// <summary>
-            /// TPM_RETURNCMD
-            /// </summary>
-            ReturnCommand = 0x0100,
-        }
         #endregion
 
         #region Constants
@@ -429,7 +303,7 @@ namespace MaterialSkin.Controls
             SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw, true);
             FormStyle = FormStyles.ActionBar_40;
 
-            Padding = new Padding(PADDING_MINIMUM, STATUS_BAR_HEIGHT+ ACTION_BAR_HEIGHT, PADDING_MINIMUM, PADDING_MINIMUM);      //Keep space for resize by mouse
+            Padding = new Padding(PADDING_MINIMUM, STATUS_BAR_HEIGHT + ACTION_BAR_HEIGHT, PADDING_MINIMUM, PADDING_MINIMUM);      //Keep space for resize by mouse
 
             _clickAnimManager = new AnimationManager()
             {
@@ -692,44 +566,44 @@ namespace MaterialSkin.Controls
             switch (direction)
             {
                 case ResizeDirection.BottomLeft:
-                    dir = (int)HT.BottomLeft;
+                    dir = (int)NativeWin.HT.BottomLeft;
                     Cursor = Cursors.SizeNESW;
                     break;
 
                 case ResizeDirection.Left:
-                    dir = (int)HT.Left;
+                    dir = (int)NativeWin.HT.Left;
                     Cursor = Cursors.SizeWE;
                     break;
 
                 case ResizeDirection.Right:
-                    dir = (int)HT.Right;
+                    dir = (int)NativeWin.HT.Right;
                     break;
 
                 case ResizeDirection.BottomRight:
-                    dir = (int)HT.BottomRight;
+                    dir = (int)NativeWin.HT.BottomRight;
                     break;
 
                 case ResizeDirection.Bottom:
-                    dir = (int)HT.Bottom;
+                    dir = (int)NativeWin.HT.Bottom;
                     break;
 
                 case ResizeDirection.Top:
-                    dir = (int)HT.Top;
+                    dir = (int)NativeWin.HT.Top;
                     break;
 
                 case ResizeDirection.TopLeft:
-                    dir = (int)HT.TopLeft;
+                    dir = (int)NativeWin.HT.TopLeft;
                     break;
 
                 case ResizeDirection.TopRight:
-                    dir = (int)HT.TopRight;
+                    dir = (int)NativeWin.HT.TopRight;
                     break;
             }
 
-            ReleaseCapture();
+            NativeWin.ReleaseCapture();
             if (dir != -1)
             {
-                SendMessage(Handle, (int)WM.NonClientLeftButtonDown, dir, 0);
+                NativeWin.SendMessage(Handle, (int)NativeWin.WM.NonClientLeftButtonDown, dir, 0);
             }
         }
 
@@ -790,7 +664,7 @@ namespace MaterialSkin.Controls
             get
             {
                 var par = base.CreateParams;
-                par.Style |= (int)WS.MinimizeBox | (int)WS.SysMenu;
+                par.Style |= (int)NativeWin.WS.MinimizeBox | (int)NativeWin.WS.SysMenu;
                 return par;
             }
         }
@@ -801,19 +675,19 @@ namespace MaterialSkin.Controls
 
             // Sets the Window Style for having a Size Frame after the form is created
             // This prevents unexpected sizing while still allowing for Aero Snapping
-            var flags = GetWindowLongPtr(Handle, -16).ToInt64();
-            SetWindowLongPtr(Handle, -16, (IntPtr)(flags | (int)WS.SizeFrame));
+            var flags = NativeWin.GetWindowLongPtr(Handle, -16).ToInt64();
+            NativeWin.SetWindowLongPtr(Handle, -16, (IntPtr)(flags | (int)NativeWin.WS.SizeFrame));
         }
 
         protected override void WndProc(ref Message m)
         {
-            var message = (WM)m.Msg;
+            var message = (NativeWin.WM)m.Msg;
             // Prevent the base class from receiving the message
-            if (message == WM.NonClientCalcSize) return;
+            if (message == NativeWin.WM.NonClientCalcSize) return;
 
             // https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-ncactivate?redirectedfrom=MSDN#parameters
             // "If this parameter is set to -1, DefWindowProc does not repaint the nonclient area to reflect the state change."
-            if (message == WM.NonClientActivate)
+            if (message == NativeWin.WM.NonClientActivate)
             {
                 m.Result = new IntPtr(-1);
                 return;
@@ -828,7 +702,7 @@ namespace MaterialSkin.Controls
                 !(_minButtonBounds.Contains(cursorPos) || _maxButtonBounds.Contains(cursorPos) || _xButtonBounds.Contains(cursorPos));
 
             // Drawer
-            if (DrawerTabControl != null && (message == WM.LeftButtonDown || message == WM.LeftButtonDoubleClick) && _drawerIconRect.Contains(cursorPos))
+            if (DrawerTabControl != null && (message == NativeWin.WM.LeftButtonDown || message == NativeWin.WM.LeftButtonDoubleClick) && _drawerIconRect.Contains(cursorPos))
             {
                 drawerControl.Toggle();
                 _clickAnimManager.SetProgress(0);
@@ -836,18 +710,18 @@ namespace MaterialSkin.Controls
                 _animationSource = cursorPos;
             }
             // Double click to maximize
-            else if (message == WM.LeftButtonDoubleClick && isOverCaption)
-            { 
+            else if (message == NativeWin.WM.LeftButtonDoubleClick && isOverCaption)
+            {
                 Maximized = !Maximized;
             }
             // Treat the Caption as if it was Non-Client
-            else if (message == WM.LeftButtonDown && isOverCaption)
+            else if (message == NativeWin.WM.LeftButtonDown && isOverCaption)
             {
-                ReleaseCapture();
-                SendMessage(Handle, (int)WM.NonClientLeftButtonDown, (int)HT.Caption, 0);
+                NativeWin.ReleaseCapture();
+                NativeWin.SendMessage(Handle, (int)NativeWin.WM.NonClientLeftButtonDown, (int)NativeWin.HT.Caption, 0);
             }
             // Default context menu
-            else if (message == WM.RightButtonDown)
+            else if (message == NativeWin.WM.RightButtonDown)
             {
                 if (_statusBarBounds.Contains(cursorPos) && !_minButtonBounds.Contains(cursorPos) &&
                     !_maxButtonBounds.Contains(cursorPos) && !_xButtonBounds.Contains(cursorPos))
@@ -857,11 +731,13 @@ namespace MaterialSkin.Controls
                     base.ContextMenuStrip = null;
 
                     // Show default system menu when right clicking titlebar
-                    var id = TrackPopupMenuEx(GetSystemMenu(Handle, false), (int)TPM.LeftAlign | (int)TPM.ReturnCommand, Cursor.Position.X, Cursor.Position.Y, Handle, IntPtr.Zero);
+                    var id = NativeWin.TrackPopupMenuEx(NativeWin.GetSystemMenu(Handle, false),
+                      (int)NativeWin.TPM.LeftAlign | (int)NativeWin.TPM.ReturnCommand,
+                      Cursor.Position.X, Cursor.Position.Y, Handle, IntPtr.Zero);
 
                     // Pass the command as a WM_SYSCOMMAND message
-                    SendMessage(Handle, (int)WM.SystemCommand, id, 0);
-                    
+                    NativeWin.SendMessage(Handle, (int)NativeWin.WM.SystemCommand, id, 0);
+
                     // restore user defined ContextMenuStrip
                     base.ContextMenuStrip = user_cms;
                 }
@@ -980,7 +856,7 @@ namespace MaterialSkin.Controls
             UpdateButtons(e.Button, e.Location, true);
 
             base.OnMouseUp(e);
-            ReleaseCapture();
+            NativeWin.ReleaseCapture();
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -1177,7 +1053,7 @@ namespace MaterialSkin.Controls
                 //Form title
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                 {
-                    Rectangle textLocation = new Rectangle(DrawerTabControl != null ? TITLE_LEFT_PADDING : TITLE_LEFT_PADDING - (ICON_SIZE + (ACTION_BAR_PADDING*2)), STATUS_BAR_HEIGHT, ClientSize.Width, ACTION_BAR_HEIGHT);
+                    Rectangle textLocation = new Rectangle(DrawerTabControl != null ? TITLE_LEFT_PADDING : TITLE_LEFT_PADDING - (ICON_SIZE + (ACTION_BAR_PADDING * 2)), STATUS_BAR_HEIGHT, ClientSize.Width, ACTION_BAR_HEIGHT);
                     NativeText.DrawTransparentText(Text, SkinManager.getLogFontByType(MaterialSkinManager.fontType.H6),
                         SkinManager.ColorScheme.TextColor,
                         textLocation.Location,
@@ -1186,58 +1062,6 @@ namespace MaterialSkin.Controls
                 }
             }
         }
-        #endregion
-
-        #region Low Level Windows Methods
-        /// <summary>
-        ///     Provides a single method to call either the 32-bit or 64-bit method based on the size of an <see cref="IntPtr"/> for getting the
-        ///     Window Style flags.<br/>
-        ///     <see href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlongptra">GetWindowLongPtr</see>
-        /// </summary>
-        private static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
-        {
-            if (IntPtr.Size == 8)
-                return GetWindowLongPtr64(hWnd, nIndex);
-            else
-                return GetWindowLong(hWnd, nIndex);
-        }
-
-        /// <summary>
-        ///     Provides a single method to call either the 32-bit or 64-bit method based on the size of an <see cref="IntPtr"/> for setting the
-        ///     Window Style flags.<br/>
-        ///     <see href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptra">SetWindowLongPtr</see>
-        /// </summary>
-        private static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
-        {
-            if (IntPtr.Size == 8)
-                return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
-            else
-                return SetWindowLong(hWnd, nIndex, dwNewLong.ToInt32());
-        }
-
-        [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
-        private static extern IntPtr GetWindowLong(IntPtr hWnd, int nIndex);
-
-        [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
-        private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
-
-        [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-        private static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
-
-        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
-        private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-
-        [DllImport("user32.dll")]
-        private static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
-
-        [DllImport("user32.dll")]
-        private static extern bool ReleaseCapture();
-
-        [DllImport("user32.dll")]
-        private static extern int TrackPopupMenuEx(IntPtr hmenu, uint fuFlags, int x, int y, IntPtr hwnd, IntPtr lptpm);
-
-        [DllImport("user32.dll")]
-        private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
         #endregion
     }
 

--- a/MaterialSkin/Controls/MaterialLabel.cs
+++ b/MaterialSkin/Controls/MaterialLabel.cs
@@ -32,18 +32,18 @@
             }
         }
 
-        [Category("Material Skin"),
-        DefaultValue(false)]
+        [Category(CategoryLabels.MaterialSkin),
+            DefaultValue(false)]
         public bool HighEmphasis { get; set; }
 
-        [Category("Material Skin"),
-        DefaultValue(false)]
+        [Category(CategoryLabels.MaterialSkin),
+            DefaultValue(false)]
         public bool UseAccent { get; set; }
 
         private MaterialSkinManager.fontType _fontType = MaterialSkinManager.fontType.Body1;
 
-        [Category("Material Skin"),
-        DefaultValue(typeof(MaterialSkinManager.fontType), "Body1")]
+        [Category(CategoryLabels.MaterialSkin),
+            DefaultValue(typeof(MaterialSkinManager.fontType), "Body1")]
         public MaterialSkinManager.fontType FontType
         {
             get

--- a/MaterialSkin/Controls/MaterialListBox.cs
+++ b/MaterialSkin/Controls/MaterialListBox.cs
@@ -39,7 +39,7 @@ namespace MaterialSkin.Controls
         private MaterialScrollBar _scrollBar;
         private object _selectedValue;
 
-        private bool _updating=false;
+        private bool _updating = false;
         private int _itemHeight;
         private bool _showBorder;
         private Color _borderColor;
@@ -84,24 +84,24 @@ namespace MaterialSkin.Controls
 
         private bool useAccentColor;
 
-        [Category("Material Skin"), DefaultValue(false), DisplayName("Use Accent Color")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), DisplayName("Use Accent Color")]
         public bool UseAccentColor
         {
             get { return useAccentColor; }
-            set { useAccentColor = value; _scrollBar.UseAccentColor = value;  Invalidate(); }
+            set { useAccentColor = value; _scrollBar.UseAccentColor = value; Invalidate(); }
         }
 
         [TypeConverter(typeof(CollectionConverter))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [Editor(typeof(MaterialItemCollectionEditor), typeof(UITypeEditor))]
-        [Category("Material Skin"), Description("Gets the items of the ListBox.")]
+        [Category(CategoryLabels.MaterialSkin), Description("Gets the items of the ListBox.")]
         public ObservableCollection<MaterialListBoxItem> Items => _items;
 
         [Browsable(false)]
-        [Category("Material Skin"), Description("Gets a collection containing the currently selected items in the ListBox.")]
+        [Category(CategoryLabels.MaterialSkin), Description("Gets a collection containing the currently selected items in the ListBox.")]
         public List<object> SelectedItems => _selectedItems;
 
-        [Browsable(false), Category("Material Skin"), Description("Gets or sets the currently selected item in the ListBox.")]
+        [Browsable(false), Category(CategoryLabels.MaterialSkin), Description("Gets or sets the currently selected item in the ListBox.")]
         public MaterialListBoxItem SelectedItem
         {
             get => _selectedItem;
@@ -114,8 +114,8 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Browsable(false), Category("Material Skin"),
-         Description("Gets the currently selected Text in the ListBox.")]
+        [Browsable(false), Category(CategoryLabels.MaterialSkin),
+             Description("Gets the currently selected Text in the ListBox.")]
         public string SelectedText
         {
             get => _selectedText;
@@ -126,7 +126,7 @@ namespace MaterialSkin.Controls
             //}
         }
 
-        [Browsable(false), Category("Material Skin"), Description("Gets or sets the zero-based index of the currently selected item in a ListBox.")]
+        [Browsable(false), Category(CategoryLabels.MaterialSkin), Description("Gets or sets the zero-based index of the currently selected item in a ListBox.")]
         public int SelectedIndex
         {
             get => _selectedIndex;
@@ -138,7 +138,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Browsable(true), Category("Material Skin"), Description("Gets the value of the member property specified by the ValueMember property.")]
+        [Browsable(true), Category(CategoryLabels.MaterialSkin), Description("Gets the value of the member property specified by the ValueMember property.")]
         public object SelectedValue
         {
             get => _selectedValue;
@@ -149,7 +149,7 @@ namespace MaterialSkin.Controls
             //}
         }
 
-        [Category("Material Skin"), DefaultValue(false), Description("Gets or sets a value indicating whether the ListBox supports multiple rows.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Gets or sets a value indicating whether the ListBox supports multiple rows.")]
         public bool MultiSelect
         {
             get => _multiSelect;
@@ -169,7 +169,7 @@ namespace MaterialSkin.Controls
         [Browsable(false)]
         public int Count => _items.Count;
 
-        [Category("Material Skin"), DefaultValue(false), Description("Gets or sets a value indicating whether the vertical scroll bar be shown or not.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Gets or sets a value indicating whether the vertical scroll bar be shown or not.")]
         public bool ShowScrollBar
         {
             get => _showScrollBar;
@@ -181,7 +181,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Material Skin"), DefaultValue(true), Description("Gets or sets a value indicating whether the border shown or not.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true), Description("Gets or sets a value indicating whether the border shown or not.")]
         public bool ShowBorder
         {
             get => _showBorder;
@@ -192,17 +192,17 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Material Skin"), Description("Gets or sets backcolor used by the control.")]
+        [Category(CategoryLabels.MaterialSkin), Description("Gets or sets backcolor used by the control.")]
         public override Color BackColor { get; set; }
 
-        [Category("Material Skin"), Description("Gets or sets forecolor used by the control.")]
+        [Category(CategoryLabels.MaterialSkin), Description("Gets or sets forecolor used by the control.")]
         public override Color ForeColor { get; set; }
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string Text { get => base.Text; set => base.Text = value; }
 
-        [Category("Material Skin"), Description("Gets or sets border color used by the control.")]
+        [Category(CategoryLabels.MaterialSkin), Description("Gets or sets border color used by the control.")]
         public Color BorderColor
         {
             get => _borderColor;
@@ -213,7 +213,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Material Skin"), DefaultValue(ListBoxStyle.SingleLine)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(ListBoxStyle.SingleLine)]
         [Description("Gets or sets the control style.")]
         public ListBoxStyle Style
         {
@@ -228,7 +228,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Material Skin"), DefaultValue(MaterialItemDensity.Dense)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(MaterialItemDensity.Dense)]
         [Description("Gets or sets list density")]
         public MaterialItemDensity Density
         {
@@ -466,8 +466,8 @@ namespace MaterialSkin.Controls
                     NativeText.DrawTransparentText(
                     itemText,
                     _primaryFont,
-                    Enabled ? (i != SelectedIndex || UseAccentColor) ? 
-                    SkinManager.TextHighEmphasisColor : 
+                    Enabled ? (i != SelectedIndex || UseAccentColor) ?
+                    SkinManager.TextHighEmphasisColor :
                     SkinManager.ColorScheme.TextColor :
                     SkinManager.TextDisabledOrHintColor, // Disabled
                     primaryTextRect.Location,
@@ -478,8 +478,8 @@ namespace MaterialSkin.Controls
                         NativeText.DrawTransparentText(
                         itemSecondaryText,
                         _secondaryFont,
-                        Enabled ? (i != SelectedIndex || UseAccentColor) ? 
-                        SkinManager.TextDisabledOrHintColor : 
+                        Enabled ? (i != SelectedIndex || UseAccentColor) ?
+                        SkinManager.TextDisabledOrHintColor :
                         SkinManager.ColorScheme.TextColor.Darken(0.25f) :
                         SkinManager.TextDisabledOrHintColor, // Disabled
                         secondaryTextRect.Location,
@@ -491,8 +491,8 @@ namespace MaterialSkin.Controls
                         NativeText.DrawMultilineTransparentText(
                         itemSecondaryText,
                         _secondaryFont,
-                        Enabled ? (i != SelectedIndex || UseAccentColor) ? 
-                        SkinManager.TextDisabledOrHintColor : 
+                        Enabled ? (i != SelectedIndex || UseAccentColor) ?
+                        SkinManager.TextDisabledOrHintColor :
                         SkinManager.ColorScheme.TextColor.Darken(0.25f) :
                         SkinManager.TextDisabledOrHintColor, // Disabled
                         secondaryTextRect.Location,
@@ -555,9 +555,9 @@ namespace MaterialSkin.Controls
 
         public void RemoveItemAt(int index)
         {
-           if (index<= _selectedIndex)
+            if (index <= _selectedIndex)
             {
-                _selectedIndex -=1;
+                _selectedIndex -= 1;
                 update_selection();
             }
             _items.RemoveAt(index);
@@ -567,7 +567,7 @@ namespace MaterialSkin.Controls
 
         public void RemoveItem(MaterialListBoxItem item)
         {
-            if (_items.IndexOf(item)<= _selectedIndex)
+            if (_items.IndexOf(item) <= _selectedIndex)
             {
                 _selectedIndex -= 1;
                 update_selection();
@@ -645,19 +645,19 @@ namespace MaterialSkin.Controls
 
         #region Events
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         [Description("Occurs when selected index change.")]
         public event SelectedIndexChangedEventHandler SelectedIndexChanged;
 
         public delegate void SelectedIndexChangedEventHandler(object sender, MaterialListBoxItem selectedItem);
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         [Description("Occurs when selected value change.")]
         public event SelectedValueEventHandler SelectedValueChanged;
 
         public delegate void SelectedValueEventHandler(object sender, MaterialListBoxItem selectedItem);
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         [Description("Occurs when item is added or removed.")]
         public event EventHandler ItemsCountChanged;
 
@@ -737,7 +737,7 @@ namespace MaterialSkin.Controls
                     _scrollBar.Value = _scrollBar.Minimum;
                 else if (_scrollBar.Maximum < _scrollBar.Value + Height)
                 {
-                    if (e.Delta>0)
+                    if (e.Delta > 0)
                         _scrollBar.Value -= e.Delta / 2;
                     else
                     { } //Do nothing, maximum reached
@@ -804,7 +804,7 @@ namespace MaterialSkin.Controls
                 index = -1;
             }
 
-            if (index >= 0 && index<Items.Count)
+            if (index >= 0 && index < Items.Count)
             {
                 _hoveredItem = index;
             }
@@ -823,24 +823,16 @@ namespace MaterialSkin.Controls
         {
             base.OnHandleCreated(e);
             _scrollBar.Size = new Size(12, Height - (ShowBorder ? 2 : 0));
-            _scrollBar.Location = new Point( Width - (_scrollBar.Width + (ShowBorder ? 1 : 0)), ShowBorder ? 1 : 0);
+            _scrollBar.Location = new Point(Width - (_scrollBar.Width + (ShowBorder ? 1 : 0)), ShowBorder ? 1 : 0);
             InvalidateScroll(this, e);
         }
 
-        public const int WM_SETCURSOR = 0x0020;
-        public const int IDC_HAND = 32649;
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern IntPtr LoadCursor(IntPtr hInstance, int lpCursorName);
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr SetCursor(IntPtr hCursor);
 
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == WM_SETCURSOR)
+            if (m.Msg == NativeWin.WM_SETCURSOR)
             {
-                SetCursor(LoadCursor(IntPtr.Zero, IDC_HAND));
+                NativeWin.SetCursor(NativeWin.LoadCursor(IntPtr.Zero, NativeWin.IDC_HAND));
                 m.Result = IntPtr.Zero;
                 return;
             }

--- a/MaterialSkin/Controls/MaterialListView.cs
+++ b/MaterialSkin/Controls/MaterialListView.cs
@@ -21,7 +21,7 @@
 
         private bool _autoSizeTable;
 
-        [Category("Appearance"), Browsable(true)]
+        [Category(CategoryLabels.Appearance), Browsable(true)]
         public bool AutoSizeTable
         {
             get
@@ -56,14 +56,14 @@
 
             // Fix for hovers, by default it doesn't redraw
             MouseLocation = new Point(-1, -1);
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
             MouseEnter += delegate
             {
                 MouseState = MouseState.HOVER;
             };
             MouseLeave += delegate
             {
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 MouseLocation = new Point(-1, -1);
                 HoveredItem = null;
                 Invalidate();

--- a/MaterialSkin/Controls/MaterialMaskedTextBox.cs
+++ b/MaterialSkin/Controls/MaterialMaskedTextBox.cs
@@ -39,7 +39,7 @@
 
         [Browsable(false)]
         public int SelectionLength { get { return baseTextBox.SelectionLength; } set { baseTextBox.SelectionLength = value; } }
-        
+
         [Browsable(false)]
         public int TextLength { get { return baseTextBox.TextLength; } }
 
@@ -51,7 +51,7 @@
 
         private bool _UseTallSize;
 
-        [Category("Material Skin"), DefaultValue(true), Description("Using a larger size enables the hint to always be visible")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true), Description("Using a larger size enables the hint to always be visible")]
         public bool UseTallSize
         {
             get { return _UseTallSize; }
@@ -65,7 +65,7 @@
         }
 
         private bool _showAssistiveText;
-        [Category("Material Skin"), DefaultValue(false), Description("Assistive elements provide additional detail about text entered into text fields. Could be Helper text or Error message.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Assistive elements provide additional detail about text entered into text fields. Could be Helper text or Error message.")]
         public bool ShowAssistiveText
         {
             get { return _showAssistiveText; }
@@ -84,7 +84,7 @@
 
         private string _helperText;
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true), Description("Helper text conveys additional guidance about the input field, such as how it will be used.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true), Description("Helper text conveys additional guidance about the input field, such as how it will be used.")]
         public string HelperText
         {
             get { return _helperText; }
@@ -97,7 +97,7 @@
 
         private string _errorMessage;
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true), Description("When text input isn't accepted, an error message can display instructions on how to fix it. Error messages are displayed below the input line, replacing helper text until fixed.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true), Description("When text input isn't accepted, an error message can display instructions on how to fix it. Error messages are displayed below the input line, replacing helper text until fixed.")]
         public string ErrorMessage
         {
             get { return _errorMessage; }
@@ -108,7 +108,7 @@
             }
         }
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true)]
         public string Hint
         {
             get { return baseTextBox.Hint; }
@@ -121,12 +121,12 @@
             }
         }
 
-        [Category("Material Skin"), DefaultValue(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true)]
         public bool UseAccent { get; set; }
 
         private Image _leadingIcon;
 
-        [Category("Material Skin"), Browsable(true), Localizable(false)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), Localizable(false)]
         /// <summary>
         /// Gets or sets the leading Icon
         /// </summary>
@@ -144,7 +144,7 @@
 
         private Image _trailingIcon;
 
-        [Category("Material Skin"), Browsable(true), Localizable(false)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), Localizable(false)]
         /// <summary>
         /// Gets or sets the trailing Icon
         /// </summary>
@@ -168,7 +168,7 @@
         }
 
         private PrefixSuffixTypes _prefixsuffix;
-        [Category("Material Skin"), DefaultValue(PrefixSuffixTypes.None), Description("Set Prefix/Suffix/None")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(PrefixSuffixTypes.None), Description("Set Prefix/Suffix/None")]
         public PrefixSuffixTypes PrefixSuffix
         {
             get { return _prefixsuffix; }
@@ -185,7 +185,7 @@
         }
 
         private string _prefixsuffixText;
-        [Category("Material Skin"), DefaultValue(""), Localizable(true), Description("Set Prefix or Suffix text")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true), Description("Set Prefix or Suffix text")]
         public string PrefixSuffixText
         {
             get { return _prefixsuffixText; }
@@ -193,9 +193,9 @@
             {
                 //if (_prefixsuffixText != value)
                 //{
-                    _prefixsuffixText = value;
-                    UpdateRects();
-                    Invalidate();
+                _prefixsuffixText = value;
+                UpdateRects();
+                Invalidate();
                 //}
             }
         }
@@ -226,61 +226,61 @@
 
         public override string Text { get { return baseTextBox.Text; } set { baseTextBox.Text = value; } }
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public HorizontalAlignment TextAlign { get { return baseTextBox.TextAlign; } set { baseTextBox.TextAlign = value; } }
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public Char PromptChar { get { return baseTextBox.PromptChar; } set { baseTextBox.PromptChar = value; } }
 
-        //[Category("Behavior")]
+        //[Category(CategoryLabels.Behavior)]
         //public CharacterCasing CharacterCasing { get { return baseTextBox.CharacterCasing; } set { baseTextBox.CharacterCasing = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool HideSelection { get { return baseTextBox.HideSelection; } set { baseTextBox.HideSelection = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool AllowPromptAsInput { get { return baseTextBox.AllowPromptAsInput; } set { baseTextBox.AllowPromptAsInput = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool AsciiOnly { get { return baseTextBox.AsciiOnly; } set { baseTextBox.AsciiOnly = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool BeepOnError { get { return baseTextBox.BeepOnError; } set { baseTextBox.BeepOnError = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public MaskFormat CutCopyMaskFormat { get { return baseTextBox.CutCopyMaskFormat; } set { baseTextBox.CutCopyMaskFormat = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool HidePromptOnLeave { get { return baseTextBox.HidePromptOnLeave; } set { baseTextBox.HidePromptOnLeave = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public InsertKeyMode InsertKeyMode { get { return baseTextBox.InsertKeyMode; } set { baseTextBox.InsertKeyMode = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public string Mask { get { return baseTextBox.Mask; } set { baseTextBox.Mask = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public int MaxLength { get { return baseTextBox.MaxLength; } set { baseTextBox.MaxLength = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public char PasswordChar { get { return baseTextBox.PasswordChar; } set { baseTextBox.PasswordChar = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool RejectInputOnFirstFailure { get { return baseTextBox.RejectInputOnFirstFailure; } set { baseTextBox.RejectInputOnFirstFailure = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool ResetOnPrompt { get { return baseTextBox.ResetOnPrompt; } set { baseTextBox.ResetOnPrompt = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool ResetOnSpace { get { return baseTextBox.ResetOnSpace; } set { baseTextBox.ResetOnSpace = value; } }
 
-        [Category("Behavior")]
-        public bool ShortcutsEnabled 
-        { 
-            get 
-            { return baseTextBox.ShortcutsEnabled; } 
-            set 
-            { 
+        [Category(CategoryLabels.Behavior)]
+        public bool ShortcutsEnabled
+        {
+            get
+            { return baseTextBox.ShortcutsEnabled; }
+            set
+            {
                 baseTextBox.ShortcutsEnabled = value;
                 if (value == false)
                 {
@@ -295,13 +295,13 @@
             }
         }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool SkipLiterals { get { return baseTextBox.SkipLiterals; } set { baseTextBox.SkipLiterals = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public MaskFormat TextMaskFormat { get { return baseTextBox.TextMaskFormat; } set { baseTextBox.TextMaskFormat = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool UseSystemPasswordChar { get { return baseTextBox.UseSystemPasswordChar; } set { baseTextBox.UseSystemPasswordChar = value; } }
 
         [Browsable(false)]
@@ -310,7 +310,7 @@
         public new object Tag { get { return baseTextBox.Tag; } set { baseTextBox.Tag = value; } }
 
         private bool _readonly;
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool ReadOnly
         {
             get { return _readonly; }
@@ -327,7 +327,7 @@
 
         private bool _animateReadOnly;
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Browsable(true)]
         public bool AnimateReadOnly
         {
@@ -341,7 +341,7 @@
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;
@@ -374,11 +374,11 @@
 
         #region "Events"
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Leading Icon is clicked")]
         public event EventHandler LeadingIconClick;
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Trailing Icon is clicked")]
         public event EventHandler TrailingIconClick;
 
@@ -506,7 +506,7 @@
             }
         }
 
-        #if NETFRAMEWORK
+#if NETFRAMEWORK
         public new event EventHandler ContextMenuChanged
         {
             add
@@ -518,7 +518,7 @@
                 baseTextBox.ContextMenuChanged -= value;
             }
         }
-        #endif
+#endif
 
         public new event EventHandler ContextMenuStripChanged
         {
@@ -916,7 +916,7 @@
             }
         }
 
-       public event MaskInputRejectedEventHandler MaskInputRejected
+        public event MaskInputRejectedEventHandler MaskInputRejected
         {
             add
             {
@@ -1264,7 +1264,7 @@
             }
         }
 
-       public event EventHandler TextAlignChanged
+        public event EventHandler TextAlignChanged
         {
             add
             {
@@ -1288,7 +1288,7 @@
             }
         }
 
-       public event TypeValidationEventHandler TypeValidationCompleted
+        public event TypeValidationEventHandler TypeValidationCompleted
         {
             add
             {
@@ -1351,7 +1351,7 @@
         private const int ACTIVATION_INDICATOR_HEIGHT = 2;
         private const int HELPER_TEXT_HEIGHT = 16;
         private const int FONT_HEIGHT = 20;
-        
+
         private int HEIGHT = 48;
 
         private int LINE_Y;
@@ -1374,7 +1374,7 @@
         {
             // Material Properties
             UseAccent = true;
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.DoubleBuffer, true);
 
@@ -1405,7 +1405,7 @@
                 Font = base.Font,
                 ForeColor = SkinManager.TextHighEmphasisColor,
                 Multiline = false,
-                Location = new Point(LEFT_PADDING, HEIGHT/2- FONT_HEIGHT/2),
+                Location = new Point(LEFT_PADDING, HEIGHT / 2 - FONT_HEIGHT / 2),
                 Width = Width - (LEFT_PADDING + RIGHT_PADDING),
                 Height = FONT_HEIGHT
             };
@@ -1442,7 +1442,7 @@
                 _animationManager.StartNewAnimation(AnimationDirection.Out);
                 UpdateRects();
             };
-            
+
             baseTextBox.TextChanged += new EventHandler(Redraw);
             baseTextBox.BackColorChanged += new EventHandler(Redraw);
 
@@ -1468,7 +1468,7 @@
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
             g.Clear(Parent.BackColor);
             SolidBrush backBrush = new SolidBrush(DrawHelper.BlendColor(Parent.BackColor, SkinManager.BackgroundAlternativeColor, SkinManager.BackgroundAlternativeColor.A));
-            
+
             //backColor
             g.FillRectangle(
                 !Enabled ? SkinManager.BackgroundDisabledBrush : // Disabled
@@ -1561,7 +1561,7 @@
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                 {
                     Rectangle suffixRect = new Rectangle(
-                        Width - _right_padding ,
+                        Width - _right_padding,
                         hasHint && UseTallSize ? (hintRect.Y + hintRect.Height) - 2 : ClientRectangle.Y,
                         _suffix_padding,
                         hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
@@ -1618,14 +1618,14 @@
             }
 
             // Draw error message
-            if (_showAssistiveText && _errorState && ErrorMessage!=null)
+            if (_showAssistiveText && _errorState && ErrorMessage != null)
             {
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                 {
                     NativeText.DrawTransparentText(
                     ErrorMessage,
                     SkinManager.getTextBoxFontBySize(hintTextSize),
-                    Enabled ? 
+                    Enabled ?
                     SkinManager.BackgroundHoverRedColor : // error state
                     SkinManager.TextDisabledOrHintColor, // Disabled
                     helperTextRect.Location,
@@ -1699,7 +1699,7 @@
             else
             {
                 base.OnMouseLeave(e);
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 Invalidate();
             }
         }
@@ -1721,7 +1721,7 @@
             base.OnCreateControl();
 
             // events
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
         }
 

--- a/MaterialSkin/Controls/MaterialMultiLineTextBox.cs
+++ b/MaterialSkin/Controls/MaterialMultiLineTextBox.cs
@@ -17,9 +17,6 @@
         [Browsable(false)]
         public MouseState MouseState { get; set; }
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
-
         private const int EM_SETCUEBANNER = 0x1501;
 
         private const char EmptyChar = (char)0;
@@ -30,20 +27,20 @@
 
         private string hint = string.Empty;
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true)]
         public string Hint
         {
             get { return hint; }
             set
             {
                 hint = value;
-                SendMessage(Handle, EM_SETCUEBANNER, (int)IntPtr.Zero, Hint);
+                NativeWin.SendMessage(Handle, EM_SETCUEBANNER, (int)IntPtr.Zero, Hint);
             }
         }
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed. To add enter in text, the user must press CTRL+Enter")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed. To add enter in text, the user must press CTRL+Enter")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;

--- a/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
+++ b/MaterialSkin/Controls/MaterialMultiLineTextBox2.cs
@@ -49,7 +49,7 @@ namespace MaterialSkin.Controls
         //Material Skin properties
 
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true)]
         public string Hint
         {
             get { return baseTextBox.Hint; }
@@ -61,7 +61,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Material Skin"), DefaultValue(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true)]
         public bool UseAccent { get; set; }
 
 
@@ -98,25 +98,25 @@ namespace MaterialSkin.Controls
 
         public override string Text { get { return baseTextBox.Text; } set { baseTextBox.Text = value; } }
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public HorizontalAlignment TextAlign { get { return baseTextBox.TextAlign; } set { baseTextBox.TextAlign = value; } }
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public ScrollBars ScrollBars { get { return baseTextBox.ScrollBars; } set { baseTextBox.ScrollBars = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public CharacterCasing CharacterCasing { get { return baseTextBox.CharacterCasing; } set { baseTextBox.CharacterCasing = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool HideSelection { get { return baseTextBox.HideSelection; } set { baseTextBox.HideSelection = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public int MaxLength { get { return baseTextBox.MaxLength; } set { baseTextBox.MaxLength = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public char PasswordChar { get { return baseTextBox.PasswordChar; } set { baseTextBox.PasswordChar = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool ShortcutsEnabled
         {
             get
@@ -137,13 +137,13 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool UseSystemPasswordChar { get { return baseTextBox.UseSystemPasswordChar; } set { baseTextBox.UseSystemPasswordChar = value; } }
 
         public new object Tag { get { return baseTextBox.Tag; } set { baseTextBox.Tag = value; } }
 
         private bool _readonly;
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool ReadOnly
         {
             get { return _readonly; }
@@ -160,7 +160,7 @@ namespace MaterialSkin.Controls
 
         private bool _animateReadOnly;
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Browsable(true)]
         public bool AnimateReadOnly
         {
@@ -174,7 +174,7 @@ namespace MaterialSkin.Controls
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed. To add enter in text, the user must press CTRL+Enter")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed. To add enter in text, the user must press CTRL+Enter")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;
@@ -1135,7 +1135,7 @@ namespace MaterialSkin.Controls
             AllowScroll = true;
             // Material Properties
             UseAccent = true;
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.DoubleBuffer, true);
 
@@ -1249,10 +1249,6 @@ namespace MaterialSkin.Controls
             }
         }
 
-
-        [DllImport("User32.dll", CharSet = CharSet.Auto, EntryPoint = "SendMessage")]
-        protected static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
-
         protected void OnMouseWheel(object sender, MouseEventArgs e)
         {
             if (AllowScroll)
@@ -1265,13 +1261,13 @@ namespace MaterialSkin.Controls
                 if (v < 0)
                 {
                     var ptrWparam = new IntPtr(SB_LINEDOWN);
-                    SendMessage(baseTextBox.Handle, WM_VSCROLL, ptrWparam, ptrLparam);
+                    NativeWin.SendMessage(baseTextBox.Handle, WM_VSCROLL, ptrWparam, ptrLparam);
                 }
                 //Up Movement
                 else if (v > 0)
                 {
                     var ptrWparam = new IntPtr(SB_LINEUP);
-                    SendMessage(baseTextBox.Handle, WM_VSCROLL, ptrWparam, ptrLparam);
+                    NativeWin.SendMessage(baseTextBox.Handle, WM_VSCROLL, ptrWparam, ptrLparam);
                 }
 
                 baseTextBox?.Focus();
@@ -1316,7 +1312,7 @@ namespace MaterialSkin.Controls
             else
             {
                 base.OnMouseLeave(e);
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 Invalidate();
             }
         }
@@ -1338,7 +1334,7 @@ namespace MaterialSkin.Controls
             base.OnCreateControl();
 
             // events
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
         }
 
         private void ContextMenuStripOnItemClickStart(object sender, ToolStripItemClickedEventArgs toolStripItemClickedEventArgs)

--- a/MaterialSkin/Controls/MaterialRadioButton.cs
+++ b/MaterialSkin/Controls/MaterialRadioButton.cs
@@ -24,7 +24,7 @@
 
         private bool ripple;
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool Ripple
         {
             get { return ripple; }
@@ -218,7 +218,7 @@
 
             if (DesignMode) return;
 
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
             GotFocus += (sender, AddingNewEventArgs) =>
             {
@@ -251,7 +251,7 @@
             MouseLeave += (sender, args) =>
             {
                 MouseLocation = new Point(-1, -1);
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 //if (Ripple && hovered)
                 //{
                 //    _hoverAM.StartNewAnimation(AnimationDirection.Out, new object[] { Checked });

--- a/MaterialSkin/Controls/MaterialScrollBar.cs
+++ b/MaterialSkin/Controls/MaterialScrollBar.cs
@@ -9,7 +9,7 @@ namespace MaterialSkin.Controls
     using System.Security;
     using System.Windows.Forms;
     using System.Runtime.InteropServices;
-    
+
     public enum MaterialScrollOrientation
     {
         Horizontal,
@@ -30,15 +30,13 @@ namespace MaterialSkin.Controls
 
         private bool useAccentColor;
 
-        [Category("Material Skin"), DefaultValue(false), DisplayName("Use Accent Color")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), DisplayName("Use Accent Color")]
         public bool UseAccentColor
         {
             get { return useAccentColor; }
             set { useAccentColor = value; Invalidate(); }
         }
 
-        [DllImport("user32.dll")]
-        public static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
 
         internal const int SCROLLBAR_DEFAULT_SIZE = 10;
 
@@ -369,7 +367,7 @@ namespace MaterialSkin.Controls
                 ControlStyles.OptimizedDoubleBuffer |
                      ControlStyles.ResizeRedraw |
                      ControlStyles.Selectable |
-//                     ControlStyles.AllPaintingInWmPaint |
+                     //                     ControlStyles.AllPaintingInWmPaint |
                      ControlStyles.SupportsTransparentBackColor |
                      ControlStyles.UserPaint, true);
 
@@ -406,14 +404,14 @@ namespace MaterialSkin.Controls
         [SecuritySafeCritical]
         public void BeginUpdate()
         {
-            SendMessage(Handle, WM_SETREDRAW, 0, 0);
+            NativeWin.SendMessage(Handle, WM_SETREDRAW, 0, 0);
             inUpdate = true;
         }
 
         [SecuritySafeCritical]
         public void EndUpdate()
         {
-            SendMessage(Handle, WM_SETREDRAW, 1, 0);
+            NativeWin.SendMessage(Handle, WM_SETREDRAW, 1, 0);
             inUpdate = false;
             SetupScrollBar();
             Refresh();

--- a/MaterialSkin/Controls/MaterialSlider.cs
+++ b/MaterialSkin/Controls/MaterialSlider.cs
@@ -38,7 +38,7 @@ namespace MaterialSkin.Controls
 
         private int _value;
         [DefaultValue(50)]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Define control value")]
         public int Value
         {
@@ -50,7 +50,7 @@ namespace MaterialSkin.Controls
                 else if (value > _rangeMax)
                     _value = _rangeMax;
                 else
-					_value = value;
+                    _value = value;
                 //_mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width) - _thumbRadius / 2));
                 _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(RangeMax - RangeMin) * (double)(_sliderRectangle.Width - _thumbRadius)));
                 RecalcutlateIndicator();
@@ -59,7 +59,7 @@ namespace MaterialSkin.Controls
 
         private int _valueMax;
         [DefaultValue(0)]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Define position indicator maximum value. Ignored when set to 0.")]
         public int ValueMax
         {
@@ -77,7 +77,7 @@ namespace MaterialSkin.Controls
 
         private int _rangeMax;
         [DefaultValue(100)]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Define control range maximum value")]
         public int RangeMax
         {
@@ -93,7 +93,7 @@ namespace MaterialSkin.Controls
 
         private int _rangeMin;
         [DefaultValue(0)]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Define control range minimum value")]
         public int RangeMin
         {
@@ -109,7 +109,7 @@ namespace MaterialSkin.Controls
 
         private string _text;
         [DefaultValue("MyData")]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Set control text")]
         public override string Text
         {
@@ -124,7 +124,7 @@ namespace MaterialSkin.Controls
 
         private string _valueSuffix;
         [DefaultValue("")]
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Description("Set control value suffix text")]
         public string ValueSuffix
         {
@@ -138,7 +138,7 @@ namespace MaterialSkin.Controls
 
         private Boolean _showText;
         [DefaultValue(true)]
-        [Category("Material Skin"), DisplayName("Show text")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Show text")]
         [Description("Show text")]
         public bool ShowText
         {
@@ -148,7 +148,7 @@ namespace MaterialSkin.Controls
 
         private Boolean _showValue;
         [DefaultValue(true)]
-        [Category("Material Skin"), DisplayName("Show value")]
+        [Category(CategoryLabels.MaterialSkin), DisplayName("Show value")]
         [Description("Show value")]
         public bool ShowValue
         {
@@ -157,7 +157,7 @@ namespace MaterialSkin.Controls
         }
 
         private bool _useAccentColor;
-        [Category("Material Skin"), DefaultValue(false), DisplayName("Use Accent Color")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), DisplayName("Use Accent Color")]
         public bool UseAccentColor
         {
             get { return _useAccentColor; }
@@ -166,7 +166,7 @@ namespace MaterialSkin.Controls
 
         private MaterialSkinManager.fontType _fontType = MaterialSkinManager.fontType.Body1;
 
-        [Category("Material Skin"),
+        [Category(CategoryLabels.MaterialSkin),
         DefaultValue(typeof(MaterialSkinManager.fontType), "Body1")]
         public MaterialSkinManager.fontType FontType
         {
@@ -187,7 +187,7 @@ namespace MaterialSkin.Controls
 
         #region "Events"
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         [Description("Occurs when value change.")]
         public delegate void ValueChanged(object sender, int newValue);
         public event ValueChanged onValueChanged;
@@ -258,7 +258,7 @@ namespace MaterialSkin.Controls
             if (_valueMax != 0 && (Value + e.Delta / -40) > _valueMax)
                 Value = _valueMax;
             else
-                Value += e.Delta/-40;
+                Value += e.Delta / -40;
             onValueChanged?.Invoke(this, _value);
         }
 
@@ -305,7 +305,7 @@ namespace MaterialSkin.Controls
             }
             else if (e.X < _sliderRectangle.X)// + (_thumbRadius / 2))
             {
-                _mouseX = _sliderRectangle.X ;
+                _mouseX = _sliderRectangle.X;
                 v = _rangeMin;
             }
             else if (e.X > _sliderRectangle.Right - _thumbRadius)// / 2)
@@ -336,20 +336,20 @@ namespace MaterialSkin.Controls
             using (NativeTextRenderer NativeText = new NativeTextRenderer(CreateGraphics()))
             {
                 textSize = NativeText.MeasureLogString(_showText ? Text : "", SkinManager.getLogFontByType(_fontType));
-                valueSize = NativeText.MeasureLogString(_showValue ? RangeMax.ToString() + _valueSuffix : "" , SkinManager.getLogFontByType(_fontType));
+                valueSize = NativeText.MeasureLogString(_showValue ? RangeMax.ToString() + _valueSuffix : "", SkinManager.getLogFontByType(_fontType));
             }
             _valueRectangle = new Rectangle(Width - valueSize.Width - _thumbRadiusHoverPressed / 4, 0, valueSize.Width + _thumbRadiusHoverPressed / 4, Height);
-            _textRectangle = new Rectangle(0, 0, textSize.Width + _thumbRadiusHoverPressed/4, Height);
-            _sliderRectangle = new Rectangle(_textRectangle.Right , 0, _valueRectangle.Left - _textRectangle.Right , _thumbRadius);
+            _textRectangle = new Rectangle(0, 0, textSize.Width + _thumbRadiusHoverPressed / 4, Height);
+            _sliderRectangle = new Rectangle(_textRectangle.Right, 0, _valueRectangle.Left - _textRectangle.Right, _thumbRadius);
             _mouseX = _sliderRectangle.X + ((int)((double)_value / (double)(_rangeMax - _rangeMin) * (double)(_sliderRectangle.Width) - _thumbRadius / 2));
             RecalcutlateIndicator();
         }
 
         private void RecalcutlateIndicator()
         {
-            _indicatorRectangle = new Rectangle(_mouseX, (Height - _thumbRadius) /2, _thumbRadius, _thumbRadius);
-            _indicatorRectangleNormal = new Rectangle(_indicatorRectangle.X, Height/2 - _thumbRadius/2, _thumbRadius, _thumbRadius);
-            _indicatorRectanglePressed = new Rectangle(_indicatorRectangle.X + _thumbRadius/2 - _thumbRadiusHoverPressed/2, Height / 2 - _thumbRadiusHoverPressed/2, _thumbRadiusHoverPressed, _thumbRadiusHoverPressed);
+            _indicatorRectangle = new Rectangle(_mouseX, (Height - _thumbRadius) / 2, _thumbRadius, _thumbRadius);
+            _indicatorRectangleNormal = new Rectangle(_indicatorRectangle.X, Height / 2 - _thumbRadius / 2, _thumbRadius, _thumbRadius);
+            _indicatorRectanglePressed = new Rectangle(_indicatorRectangle.X + _thumbRadius / 2 - _thumbRadiusHoverPressed / 2, Height / 2 - _thumbRadiusHoverPressed / 2, _thumbRadiusHoverPressed, _thumbRadiusHoverPressed);
             Invalidate();
         }
 
@@ -359,7 +359,7 @@ namespace MaterialSkin.Controls
             g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
             g.Clear(Parent.BackColor);
-            
+
             Color _inactiveTrackColor;
             Color _accentColor;
             Brush _accentBrush;
@@ -390,7 +390,7 @@ namespace MaterialSkin.Controls
             //_disabledBrush = new SolidBrush(_disabledColor);
             //_thumbHoverColor = Color.FromArgb((int)(2.55 * 15), (Value == 0 ? Color.Gray : _accentColor));
             //_thumbPressedColor = Color.FromArgb((int)(2.55 * 30), (Value == 0 ? Color.Gray : _accentColor));            _thumbHoverColor = Color.FromArgb((int)(2.55 * 15), (Value == 0 ? Color.Gray : _accentColor));
-            _thumbHoverColor = Color.FromArgb((int)(2.55 * 15),  _accentColor);
+            _thumbHoverColor = Color.FromArgb((int)(2.55 * 15), _accentColor);
             _thumbPressedColor = Color.FromArgb((int)(2.55 * 30), _accentColor);
             //Pen LinePen = new Pen(_disabledColor, _inactiveTrack);
 
@@ -398,9 +398,9 @@ namespace MaterialSkin.Controls
             //g.DrawLine(LinePen, _indicatorSize / 2, Height / 2 + (Height - _indicatorSize) / 2, Width - _indicatorSize / 2, Height / 2 + (Height - _indicatorSize) / 2);
             //g.DrawLine(LinePen, _sliderRectangle.X + (_indicatorSize / 2), Height / 2 , _sliderRectangle.Right - (_indicatorSize / 2), Height / 2 );
 
-            GraphicsPath _inactiveTrackPath = DrawHelper.CreateRoundRect(_sliderRectangle.X + (_thumbRadius / 2), _sliderRectangle.Y + Height / 2 - _inactiveTrack/2, _sliderRectangle.Width - _thumbRadius, _inactiveTrack, 2);
+            GraphicsPath _inactiveTrackPath = DrawHelper.CreateRoundRect(_sliderRectangle.X + (_thumbRadius / 2), _sliderRectangle.Y + Height / 2 - _inactiveTrack / 2, _sliderRectangle.Width - _thumbRadius, _inactiveTrack, 2);
             //g.FillPath(_disabledBrush, _inactiveTrackPath);
-                GraphicsPath _activeTrackPath = DrawHelper.CreateRoundRect(_sliderRectangle.X + (_thumbRadius / 2), _sliderRectangle.Y + Height / 2 - _activeTrack / 2, _indicatorRectangleNormal.X - _sliderRectangle.X, _activeTrack, 2);
+            GraphicsPath _activeTrackPath = DrawHelper.CreateRoundRect(_sliderRectangle.X + (_thumbRadius / 2), _sliderRectangle.Y + Height / 2 - _activeTrack / 2, _indicatorRectangleNormal.X - _sliderRectangle.X, _activeTrack, 2);
 
             if (Enabled)
             {
@@ -451,16 +451,16 @@ namespace MaterialSkin.Controls
                     _textRectangle.Location,
                     _textRectangle.Size,
                     NativeTextRenderer.TextAlignFlags.Left | NativeTextRenderer.TextAlignFlags.Middle);
- 
-                if (_showValue==true)
-                // Draw value
-                NativeText.DrawTransparentText(
-                    Value.ToString()+ValueSuffix,
-                    SkinManager.getLogFontByType(_fontType),
-                    Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
-                    _valueRectangle.Location,
-                    _valueRectangle.Size,
-                    NativeTextRenderer.TextAlignFlags.Right | NativeTextRenderer.TextAlignFlags.Middle);
+
+                if (_showValue == true)
+                    // Draw value
+                    NativeText.DrawTransparentText(
+                        Value.ToString() + ValueSuffix,
+                        SkinManager.getLogFontByType(_fontType),
+                        Enabled ? SkinManager.TextHighEmphasisColor : SkinManager.TextDisabledOrHintColor,
+                        _valueRectangle.Location,
+                        _valueRectangle.Size,
+                        NativeTextRenderer.TextAlignFlags.Right | NativeTextRenderer.TextAlignFlags.Middle);
             }
 
         }

--- a/MaterialSkin/Controls/MaterialSnackBar.cs
+++ b/MaterialSkin/Controls/MaterialSnackBar.cs
@@ -26,14 +26,14 @@
 
         #region "Events"
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Action button is clicked")]
         public event EventHandler ActionButtonClick;
 
         #endregion
 
 
-        [Category("Material Skin"), DefaultValue(false), DisplayName("Use Accent Color")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), DisplayName("Use Accent Color")]
         public bool UseAccentColor
         {
             get { return _useAccentColor; }
@@ -44,7 +44,7 @@
         /// <summary>
         /// Get or Set SnackBar show duration in milliseconds
         /// </summary>
-        [Category("Material Skin"), DefaultValue(2000)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(2000)]
         public int Duration
         {
             get
@@ -61,7 +61,7 @@
         /// <summary>
         /// The Text which gets displayed as the Content
         /// </summary>
-        [Category("Material Skin"), DefaultValue("SnackBar text")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue("SnackBar text")]
         public new String Text
         {
             get
@@ -77,7 +77,7 @@
         }
 
         private bool _showActionButton;
-        [Category("Material Skin"), DefaultValue(false), DisplayName("Show Action Button")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), DisplayName("Show Action Button")]
         public bool ShowActionButton
         {
             get { return _showActionButton; }
@@ -88,7 +88,7 @@
         /// <summary>
         /// The Text which gets displayed as the Content
         /// </summary>
-        [Category("Material Skin"), DefaultValue("OK")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue("OK")]
         public String ActionButtonText
         {
             get
@@ -107,16 +107,6 @@
         /// </summary>
         //public ObservableCollection<MaterialButton> Buttons { get; set; }
 
-        [DllImport("Gdi32.dll", EntryPoint = "CreateRoundRectRgn")]
-        private static extern IntPtr CreateRoundRectRgn
-        (
-            int nLeftRect,     // x-coordinate of upper-left corner
-            int nTopRect,      // y-coordinate of upper-left corner
-            int nRightRect,    // x-coordinate of lower-right corner
-            int nBottomRect,   // y-coordinate of lower-right corner
-            int nWidthEllipse, // width of ellipse
-            int nHeightEllipse // height of ellipse
-        );
 
         /// <summary>
         /// Constructer Setting up the Layout
@@ -140,7 +130,7 @@
 
             this.ShowActionButton = ShowActionButton;
 
-            Region = System.Drawing.Region.FromHrgn(CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
+            Region = System.Drawing.Region.FromHrgn(NativeWin.CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
 
             _AnimationManager = new AnimationManager();
             _AnimationManager.AnimationType = AnimationType.EaseOut;
@@ -223,7 +213,7 @@
             _actionButton.Visible = _showActionButton;
 
             Width = TextRenderer.MeasureText(_text, SkinManager.getFontByType(MaterialSkinManager.fontType.Body2)).Width + (2 * LEFT_RIGHT_PADDING) + _actionButton.Width + 48;
-            Region = System.Drawing.Region.FromHrgn(CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
+            Region = System.Drawing.Region.FromHrgn(NativeWin.CreateRoundRectRgn(0, 0, Width, Height, 6, 6));
 
         }
 
@@ -234,7 +224,7 @@
             Close();
         }
 
-         protected override void OnResize(EventArgs e)
+        protected override void OnResize(EventArgs e)
         {
             base.OnResize(e);
             UpdateRects();
@@ -274,7 +264,7 @@
 
             e.Graphics.Clear(BackColor);
 
-            
+
             // Calc text Rect
             Rectangle textRect = new Rectangle(
                 LEFT_RIGHT_PADDING,
@@ -357,8 +347,8 @@
 
             base.WndProc(ref message);
         }
-        
-       public new void Show()
+
+        public new void Show()
         {
             if (Owner == null)
             {

--- a/MaterialSkin/Controls/MaterialSwitch.cs
+++ b/MaterialSkin/Controls/MaterialSwitch.cs
@@ -24,7 +24,7 @@
 
         private bool _ripple;
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public bool Ripple
         {
             get { return _ripple; }
@@ -42,7 +42,7 @@
             }
         }
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         [Browsable(true), DefaultValue(false), EditorBrowsable(EditorBrowsableState.Always)]
         public bool ReadOnly { get; set; }
 
@@ -272,7 +272,7 @@
 
             if (DesignMode) return;
 
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
             GotFocus += (sender, AddingNewEventArgs) =>
             {
@@ -305,7 +305,7 @@
             MouseLeave += (sender, args) =>
             {
                 MouseLocation = new Point(-1, -1);
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 //if (Ripple && hovered)
                 //{
                 //    _hoverAM.StartNewAnimation(AnimationDirection.Out, new object[] { Checked });

--- a/MaterialSkin/Controls/MaterialTabSelector.cs
+++ b/MaterialSkin/Controls/MaterialTabSelector.cs
@@ -37,7 +37,7 @@
 
         private MaterialTabControl _baseTabControl;
 
-        [Category("Material Skin"), Browsable(true)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true)]
         public MaterialTabControl BaseTabControl
         {
             get { return _baseTabControl; }
@@ -79,7 +79,7 @@
 
         private const int ICON_SIZE = 24;
         private const int FIRST_TAB_PADDING = 50;
-        private const int TAB_HEADER_PADDING = 24;
+        private const int TAB_HEADER_PADDING = 16;
         private const int TAB_WIDTH_MIN = 160;
         private const int TAB_WIDTH_MAX = 264;
 
@@ -87,7 +87,7 @@
 
         private CustomCharacterCasing _characterCasing;
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public CustomCharacterCasing CharacterCasing
         {
             get => _characterCasing;
@@ -100,8 +100,8 @@
         }
         private int _tab_indicator_height;
 
-        [Category("Material Skin"), Browsable(true), DisplayName("Tab Indicator Height"), DefaultValue(2)]
-        public int TabIndicatorHeight 
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), DisplayName("Tab Indicator Height"), DefaultValue(2)]
+        public int TabIndicatorHeight
         {
             get { return _tab_indicator_height; }
             set
@@ -124,7 +124,7 @@
         }
 
         private TabLabelStyle _tabLabel;
-        [Category("Material Skin"), Browsable(true), DisplayName("Tab Label"), DefaultValue(TabLabelStyle.Text)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), DisplayName("Tab Label"), DefaultValue(TabLabelStyle.Text)]
         public TabLabelStyle TabLabel
         {
             get { return _tabLabel; }
@@ -191,9 +191,9 @@
 
             //Draw tab headers
             if (_tab_over_index >= 0)
-            { 
+            {
                 //Change mouse over tab background color
-                g.FillRectangle(SkinManager.BackgroundHoverBrush , _tabRects[_tab_over_index].X, _tabRects[_tab_over_index].Y , _tabRects[_tab_over_index].Width, _tabRects[_tab_over_index].Height - _tab_indicator_height);
+                g.FillRectangle(SkinManager.BackgroundHoverBrush, _tabRects[_tab_over_index].X, _tabRects[_tab_over_index].Y, _tabRects[_tab_over_index].Width, _tabRects[_tab_over_index].Height - _tab_indicator_height);
             }
 
             foreach (TabPage tabPage in _baseTabControl.TabPages)
@@ -206,7 +206,7 @@
                     using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                     {
                         Size textSize = TextRenderer.MeasureText(_baseTabControl.TabPages[currentTabIndex].Text, Font);
-                        Rectangle textLocation = new Rectangle(_tabRects[currentTabIndex].X+ (TAB_HEADER_PADDING/2), _tabRects[currentTabIndex].Y, _tabRects[currentTabIndex].Width - (TAB_HEADER_PADDING), _tabRects[currentTabIndex].Height);
+                        Rectangle textLocation = new Rectangle(_tabRects[currentTabIndex].X + (TAB_HEADER_PADDING / 2), _tabRects[currentTabIndex].Y, _tabRects[currentTabIndex].Width - (TAB_HEADER_PADDING), _tabRects[currentTabIndex].Height);
 
                         if (_tabLabel == TabLabelStyle.IconAndText)
                         {
@@ -214,7 +214,7 @@
                             textLocation.Height = 10;
                         }
 
-                        if (((TAB_HEADER_PADDING*2) + textSize.Width < TAB_WIDTH_MAX))
+                        if (((TAB_HEADER_PADDING * 2) + textSize.Width < TAB_WIDTH_MAX))
                         {
                             NativeText.DrawTransparentText(
                             CharacterCasing == CustomCharacterCasing.Upper ? tabPage.Text.ToUpper() :
@@ -259,10 +259,10 @@
                         {
                             iconRect.Y = 12;
                         }
-                        g.DrawImage(!String.IsNullOrEmpty(tabPage.ImageKey) ? _baseTabControl.ImageList.Images[tabPage.ImageKey]: _baseTabControl.ImageList.Images[tabPage.ImageIndex], iconRect);
+                        g.DrawImage(!String.IsNullOrEmpty(tabPage.ImageKey) ? _baseTabControl.ImageList.Images[tabPage.ImageKey] : _baseTabControl.ImageList.Images[tabPage.ImageIndex], iconRect);
                     }
                 }
-           }
+            }
 
             //Animate tab indicator
             var previousSelectedTabIndexIfHasOne = _previousSelectedTabIndex == -1 ? _baseTabControl.SelectedIndex : _previousSelectedTabIndex;
@@ -379,7 +379,7 @@
                             else if (TabWidth < TAB_WIDTH_MIN)
                                 TabWidth = TAB_WIDTH_MIN;
 
-                            if (i==0)
+                            if (i == 0)
                                 _tabRects.Add(new Rectangle(FIRST_TAB_PADDING - (TAB_HEADER_PADDING), 0, TabWidth, Height));
                             else
                                 _tabRects.Add(new Rectangle(_tabRects[i - 1].Right, 0, TabWidth, Height));

--- a/MaterialSkin/Controls/MaterialTextBox.cs
+++ b/MaterialSkin/Controls/MaterialTextBox.cs
@@ -26,12 +26,12 @@
         [Browsable(false)]
         public MouseState MouseState { get; set; }
 
-        [Category("Material Skin"), DefaultValue(false)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false)]
         public bool Password { get; set; }
 
         private bool _UseTallSize;
 
-        [Category("Material Skin"), DefaultValue(true), Description("Using a larger size enables the hint to always be visible")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true), Description("Using a larger size enables the hint to always be visible")]
         public bool UseTallSize
         {
             get { return _UseTallSize; }
@@ -45,12 +45,12 @@
             }
         }
 
-        [Category("Material Skin"), DefaultValue(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true)]
         public bool UseAccent { get; set; }
 
         private string _hint = string.Empty;
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true)]
         public string Hint
         {
             get { return _hint; }
@@ -64,7 +64,7 @@
 
         private Image _leadingIcon;
 
-        [Category("Material Skin"), Browsable(true), Localizable(false)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), Localizable(false)]
         /// <summary>
         /// Gets or sets the leading Icon
         /// </summary>
@@ -89,7 +89,7 @@
 
         private Image _trailingIcon;
 
-        [Category("Material Skin"), Browsable(true), Localizable(false)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), Localizable(false)]
         /// <summary>
         /// Gets or sets the trailing Icon
         /// </summary>
@@ -160,8 +160,8 @@
 
         private bool hasHint;
         private bool _errorState = false;
-        private int _left_padding ;
-        private int _right_padding ;
+        private int _left_padding;
+        private int _right_padding;
         private Rectangle _leadingIconBounds;
         private Rectangle _trailingIconBounds;
         private Rectangle _textfieldBounds;
@@ -172,7 +172,7 @@
 
         private bool _animateReadOnly;
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Browsable(true)]
         public bool AnimateReadOnly
         {
@@ -186,7 +186,7 @@
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;
@@ -207,11 +207,11 @@
 
         #region "Events"
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Leading Icon is clicked")]
         public event EventHandler LeadingIconClick;
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Trailing Icon is clicked")]
         public event EventHandler TrailingIconClick;
 
@@ -257,9 +257,6 @@
 
         private const int EM_SETPASSWORDCHAR = 0x00cc;
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
-
         protected override void OnCreateControl()
         {
             base.OnCreateControl();
@@ -268,7 +265,7 @@
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.DoubleBuffer | ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint, true);
 
-            if (Password) SendMessage(Handle, EM_SETPASSWORDCHAR, 'T', 0);
+            if (Password) NativeWin.SendMessage(Handle, EM_SETPASSWORDCHAR, 'T', 0);
 
             // Size and padding
             HEIGHT = UseTallSize ? 50 : 36;
@@ -277,7 +274,7 @@
             UpdateRects();
 
             // events
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
             LostFocus += (sender, args) => _animationManager.StartNewAnimation(AnimationDirection.Out);
             GotFocus += (sender, args) =>
             {
@@ -290,17 +287,17 @@
             };
             MouseLeave += (sender, args) =>
             {
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 Invalidate();
             };
             HScroll += (sender, args) =>
             {
-                SendMessage(this.Handle, EM_GETSCROLLPOS, 0, ref scrollPos);
+                NativeWin.SendMessage(this.Handle, EM_GETSCROLLPOS, 0, ref scrollPos);
                 Invalidate();
             };
             KeyDown += (sender, args) =>
             {
-                SendMessage(this.Handle, EM_GETSCROLLPOS, 0, ref scrollPos);
+                NativeWin.SendMessage(this.Handle, EM_GETSCROLLPOS, 0, ref scrollPos);
             };
         }
 
@@ -308,8 +305,6 @@
         private const int EM_GETSCROLLPOS = WM_USER + 221;
         private const int WM_USER = 0x400;
 
-        [DllImport("user32.dll")]
-        private static extern IntPtr SendMessage(IntPtr hWnd, Int32 wMsg, Int32 wParam, ref Point lParam);
 
         public override Size GetPreferredSize(Size proposedSize)
         {
@@ -363,7 +358,7 @@
             if (_trailingIcon == null && _leadingIcon == null) return;
 
             // Calculate lightness and color
-            float l = (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT ) ? 0f : 1f;
+            float l = (SkinManager.Theme == MaterialSkinManager.Themes.LIGHT) ? 0f : 1f;
 
             // Create matrices
             float[][] matrixGray = {
@@ -510,13 +505,13 @@
 
             if (RedefineTextField)
             {
-            var rect = new Rectangle(_left_padding, UseTallSize ? hasHint ?
-        (HINT_TEXT_SMALL_Y + HINT_TEXT_SMALL_SIZE) : // Has hint and it's tall
-        (int)(LINE_Y / 3.5) : // No hint and tall
-        Height / 5, // not tall
-        ClientSize.Width - _left_padding - _right_padding, LINE_Y);
-            RECT rc = new RECT(rect);
-            SendMessageRefRect(Handle, EM_SETRECT, 0, ref rc);
+                var rect = new Rectangle(_left_padding, UseTallSize ? hasHint ?
+            (HINT_TEXT_SMALL_Y + HINT_TEXT_SMALL_SIZE) : // Has hint and it's tall
+            (int)(LINE_Y / 3.5) : // No hint and tall
+            Height / 5, // not tall
+            ClientSize.Width - _left_padding - _right_padding, LINE_Y);
+                NativeWin.RECT rc = new NativeWin.RECT(rect);
+                NativeWin.SendMessageRefRect(Handle, NativeWin.EM_SETRECT, 0, ref rc);
             }
 
         }
@@ -558,7 +553,7 @@
             //Trailing Icon
             if (TrailingIcon != null)
             {
-                if(_errorState)
+                if (_errorState)
                     g.FillRectangle(iconsErrorBrushes["_trailingIcon"], _trailingIconBounds);
                 else
                     g.FillRectangle(iconsBrushes["_trailingIcon"], _trailingIconBounds);
@@ -829,43 +824,15 @@
             }
         }
 
-        // Cursor flickering fix
-        private const int WM_SETCURSOR = 0x0020;
-
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == WM_SETCURSOR)
+            // Cursor flickering fix
+            if (m.Msg == NativeWin.WM_SETCURSOR)
                 Cursor.Current = this.Cursor;
             else
                 base.WndProc(ref m);
         }
 
-        // Padding
-        private const int EM_SETRECT = 0xB3;
-
-        [DllImport(@"User32.dll", EntryPoint = @"SendMessage", CharSet = CharSet.Auto)]
-        private static extern int SendMessageRefRect(IntPtr hWnd, uint msg, int wParam, ref RECT rect);
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct RECT
-        {
-            public readonly int Left;
-            public readonly int Top;
-            public readonly int Right;
-            public readonly int Bottom;
-
-            private RECT(int left, int top, int right, int bottom)
-            {
-                Left = left;
-                Top = top;
-                Right = right;
-                Bottom = bottom;
-            }
-
-            public RECT(Rectangle r) : this(r.Left, r.Top, r.Right, r.Bottom)
-            {
-            }
-        }
     }
 
     [ToolboxItem(false)]

--- a/MaterialSkin/Controls/MaterialTextBox2.cs
+++ b/MaterialSkin/Controls/MaterialTextBox2.cs
@@ -51,7 +51,7 @@ namespace MaterialSkin.Controls
 
         private bool _UseTallSize;
 
-        [Category("Material Skin"), DefaultValue(true), Description("Using a larger size enables the hint to always be visible")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true), Description("Using a larger size enables the hint to always be visible")]
         public bool UseTallSize
         {
             get { return _UseTallSize; }
@@ -65,7 +65,7 @@ namespace MaterialSkin.Controls
         }
 
         private bool _showAssistiveText;
-        [Category("Material Skin"), DefaultValue(false), Description("Assistive elements provide additional detail about text entered into text fields. Could be Helper text or Error message.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Assistive elements provide additional detail about text entered into text fields. Could be Helper text or Error message.")]
         public bool ShowAssistiveText
         {
             get { return _showAssistiveText; }
@@ -84,7 +84,7 @@ namespace MaterialSkin.Controls
 
         private string _helperText;
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true), Description("Helper text conveys additional guidance about the input field, such as how it will be used.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true), Description("Helper text conveys additional guidance about the input field, such as how it will be used.")]
         public string HelperText
         {
             get { return _helperText; }
@@ -97,7 +97,7 @@ namespace MaterialSkin.Controls
 
         private string _errorMessage;
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true), Description("When text input isn't accepted, an error message can display instructions on how to fix it. Error messages are displayed below the input line, replacing helper text until fixed.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true), Description("When text input isn't accepted, an error message can display instructions on how to fix it. Error messages are displayed below the input line, replacing helper text until fixed.")]
         public string ErrorMessage
         {
             get { return _errorMessage; }
@@ -108,7 +108,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Material Skin"), DefaultValue(""), Localizable(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true)]
         public string Hint
         {
             get { return baseTextBox.Hint; }
@@ -121,12 +121,12 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Material Skin"), DefaultValue(true)]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(true)]
         public bool UseAccent { get; set; }
 
         private Image _leadingIcon;
 
-        [Category("Material Skin"), Browsable(true), Localizable(false)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), Localizable(false)]
         /// <summary>
         /// Gets or sets the leading Icon
         /// </summary>
@@ -144,7 +144,7 @@ namespace MaterialSkin.Controls
 
         private Image _trailingIcon;
 
-        [Category("Material Skin"), Browsable(true), Localizable(false)]
+        [Category(CategoryLabels.MaterialSkin), Browsable(true), Localizable(false)]
         /// <summary>
         /// Gets or sets the trailing Icon
         /// </summary>
@@ -168,7 +168,7 @@ namespace MaterialSkin.Controls
         }
 
         private PrefixSuffixTypes _prefixsuffix;
-        [Category("Material Skin"), DefaultValue(PrefixSuffixTypes.None), Description("Set Prefix/Suffix/None")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(PrefixSuffixTypes.None), Description("Set Prefix/Suffix/None")]
         public PrefixSuffixTypes PrefixSuffix
         {
             get { return _prefixsuffix; }
@@ -185,7 +185,7 @@ namespace MaterialSkin.Controls
         }
 
         private string _prefixsuffixText;
-        [Category("Material Skin"), DefaultValue(""), Localizable(true), Description("Set Prefix or Suffix text")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(""), Localizable(true), Description("Set Prefix or Suffix text")]
         public string PrefixSuffixText
         {
             get { return _prefixsuffixText; }
@@ -193,9 +193,9 @@ namespace MaterialSkin.Controls
             {
                 //if (_prefixsuffixText != value)
                 //{
-                    _prefixsuffixText = value;
-                    UpdateRects();
-                    Invalidate();
+                _prefixsuffixText = value;
+                UpdateRects();
+                Invalidate();
                 //}
             }
         }
@@ -228,28 +228,28 @@ namespace MaterialSkin.Controls
 
         public override string Text { get { return baseTextBox.Text; } set { baseTextBox.Text = value; UpdateRects(); } }
 
-        [Category("Appearance")]
+        [Category(CategoryLabels.Appearance)]
         public HorizontalAlignment TextAlign { get { return baseTextBox.TextAlign; } set { baseTextBox.TextAlign = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public CharacterCasing CharacterCasing { get { return baseTextBox.CharacterCasing; } set { baseTextBox.CharacterCasing = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool HideSelection { get { return baseTextBox.HideSelection; } set { baseTextBox.HideSelection = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public int MaxLength { get { return baseTextBox.MaxLength; } set { baseTextBox.MaxLength = value; } }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public char PasswordChar { get { return baseTextBox.PasswordChar; } set { baseTextBox.PasswordChar = value; } }
 
-        [Category("Behavior")]
-        public bool ShortcutsEnabled 
-        { 
-            get 
-            { return baseTextBox.ShortcutsEnabled; } 
-            set 
-            { 
+        [Category(CategoryLabels.Behavior)]
+        public bool ShortcutsEnabled
+        {
+            get
+            { return baseTextBox.ShortcutsEnabled; }
+            set
+            {
                 baseTextBox.ShortcutsEnabled = value;
                 if (value == false)
                 {
@@ -264,13 +264,13 @@ namespace MaterialSkin.Controls
             }
         }
 
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool UseSystemPasswordChar { get { return baseTextBox.UseSystemPasswordChar; } set { baseTextBox.UseSystemPasswordChar = value; } }
 
         public new object Tag { get { return baseTextBox.Tag; } set { baseTextBox.Tag = value; } }
 
         private bool _readonly;
-        [Category("Behavior")]
+        [Category(CategoryLabels.Behavior)]
         public bool ReadOnly
         {
             get { return _readonly; }
@@ -287,7 +287,7 @@ namespace MaterialSkin.Controls
 
         private bool _animateReadOnly;
 
-        [Category("Material Skin")]
+        [Category(CategoryLabels.MaterialSkin)]
         [Browsable(true)]
         public bool AnimateReadOnly
         {
@@ -301,7 +301,7 @@ namespace MaterialSkin.Controls
 
         private bool _leaveOnEnterKey;
 
-        [Category("Material Skin"), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
+        [Category(CategoryLabels.MaterialSkin), DefaultValue(false), Description("Select next control which have TabStop property set to True when enter key is pressed.")]
         public bool LeaveOnEnterKey
         {
             get => _leaveOnEnterKey;
@@ -340,11 +340,11 @@ namespace MaterialSkin.Controls
 
         #region "Events"
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Leading Icon is clicked")]
         public event EventHandler LeadingIconClick;
 
-        [Category("Action")]
+        [Category(CategoryLabels.Action)]
         [Description("Fires when Trailing Icon is clicked")]
         public event EventHandler TrailingIconClick;
 
@@ -472,7 +472,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-        #if NETFRAMEWORK
+#if NETFRAMEWORK
         public new event EventHandler ContextMenuChanged
         {
             add
@@ -484,7 +484,7 @@ namespace MaterialSkin.Controls
                 baseTextBox.ContextMenuChanged -= value;
             }
         }
-        #endif
+#endif
 
         public new event EventHandler ContextMenuStripChanged
         {
@@ -1194,7 +1194,7 @@ namespace MaterialSkin.Controls
             }
         }
 
-       public event EventHandler TextAlignChanged
+        public event EventHandler TextAlignChanged
         {
             add
             {
@@ -1267,7 +1267,7 @@ namespace MaterialSkin.Controls
         private const int ACTIVATION_INDICATOR_HEIGHT = 2;
         private const int HELPER_TEXT_HEIGHT = 16;
         private const int FONT_HEIGHT = 20;
-        
+
         private int HEIGHT = 48;
 
         private int LINE_Y;
@@ -1290,7 +1290,7 @@ namespace MaterialSkin.Controls
         {
             // Material Properties
             UseAccent = true;
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.DoubleBuffer, true);
 
@@ -1321,7 +1321,7 @@ namespace MaterialSkin.Controls
                 Font = base.Font,
                 ForeColor = SkinManager.TextHighEmphasisColor,
                 Multiline = false,
-                Location = new Point(LEFT_PADDING, HEIGHT/2- FONT_HEIGHT/2),
+                Location = new Point(LEFT_PADDING, HEIGHT / 2 - FONT_HEIGHT / 2),
                 Width = Width - (LEFT_PADDING + RIGHT_PADDING),
                 Height = FONT_HEIGHT
             };
@@ -1383,7 +1383,7 @@ namespace MaterialSkin.Controls
             g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
             g.Clear(Parent.BackColor);
             SolidBrush backBrush = new SolidBrush(DrawHelper.BlendColor(Parent.BackColor, SkinManager.BackgroundAlternativeColor, SkinManager.BackgroundAlternativeColor.A));
-            
+
             //backColor
             g.FillRectangle(
                 !Enabled ? SkinManager.BackgroundDisabledBrush : // Disabled
@@ -1456,7 +1456,7 @@ namespace MaterialSkin.Controls
                     Rectangle prefixRect = new Rectangle(
                         _left_padding - _prefix_padding,
                         hasHint && UseTallSize ? (hintRect.Y + hintRect.Height) - 2 : ClientRectangle.Y,
-//                        NativeText.MeasureLogString(_prefixsuffixText, SkinManager.getLogFontByType(MaterialSkinManager.fontType.Subtitle1)).Width,
+                        //                        NativeText.MeasureLogString(_prefixsuffixText, SkinManager.getLogFontByType(MaterialSkinManager.fontType.Subtitle1)).Width,
                         _prefix_padding,
                         hasHint && UseTallSize ? LINE_Y - (hintRect.Y + hintRect.Height) : LINE_Y);
 
@@ -1477,7 +1477,7 @@ namespace MaterialSkin.Controls
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                 {
                     Rectangle suffixRect = new Rectangle(
-                        Width - _right_padding ,
+                        Width - _right_padding,
                         hasHint && UseTallSize ? (hintRect.Y + hintRect.Height) - 2 : ClientRectangle.Y,
                         //NativeText.MeasureLogString(_prefixsuffixText, SkinManager.getLogFontByType(MaterialSkinManager.fontType.Subtitle1)).Width + PREFIX_SUFFIX_PADDING,
                         _suffix_padding,
@@ -1495,7 +1495,7 @@ namespace MaterialSkin.Controls
             }
 
             // Draw hint text
-            if(hasHint && UseTallSize && (isFocused || userTextPresent))
+            if (hasHint && UseTallSize && (isFocused || userTextPresent))
             {
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                 {
@@ -1535,14 +1535,14 @@ namespace MaterialSkin.Controls
             }
 
             // Draw error message
-            if (_showAssistiveText && _errorState && ErrorMessage!=null)
+            if (_showAssistiveText && _errorState && ErrorMessage != null)
             {
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(g))
                 {
                     NativeText.DrawTransparentText(
                     ErrorMessage,
                     SkinManager.getTextBoxFontBySize(hintTextSize),
-                    Enabled ? 
+                    Enabled ?
                     SkinManager.BackgroundHoverRedColor : // error state
                     SkinManager.TextDisabledOrHintColor, // Disabled
                     helperTextRect.Location,
@@ -1615,7 +1615,7 @@ namespace MaterialSkin.Controls
             else
             {
                 base.OnMouseLeave(e);
-                MouseState = MouseState.OUT;
+                MouseState = MouseState.OUT_;
                 Invalidate();
             }
         }
@@ -1637,7 +1637,7 @@ namespace MaterialSkin.Controls
             base.OnCreateControl();
 
             // events
-            MouseState = MouseState.OUT;
+            MouseState = MouseState.OUT_;
 
         }
 
@@ -1838,7 +1838,7 @@ namespace MaterialSkin.Controls
                 iconsErrorBrushes.Add("_trailingIcon", textureBrushRed);
             }
         }
-        
+
         #endregion
 
         private void UpdateHeight()
@@ -1870,7 +1870,7 @@ namespace MaterialSkin.Controls
             }
             else
                 _prefix_padding = 0;
-                
+
             if (_prefixsuffix == PrefixSuffixTypes.Suffix && _prefixsuffixText != null && _prefixsuffixText.Length > 0)
             {
                 using (NativeTextRenderer NativeText = new NativeTextRenderer(CreateGraphics()))

--- a/MaterialSkin/Globals.cs
+++ b/MaterialSkin/Globals.cs
@@ -1,0 +1,23 @@
+﻿
+namespace MaterialSkin
+{
+    internal class Globals
+    {
+        /// <summary>
+        /// Left and Right padding applied to each header of a Material Tab Selector control
+        /// </summary>
+        internal const int TAB_HEADER_PADDING = 20;
+    }
+
+
+    internal static class CategoryLabels
+    {
+        internal const string MaterialSkin = "Material Skin";
+        internal const string Drawer = "Drawer";
+        internal const string Behavior = "Behavior";
+        internal const string Layout = "Layout";
+        internal const string Appearance = "Appearance";
+        internal const string Action = "Action";
+        internal const string Disposition = "Disposition";
+    }
+}

--- a/MaterialSkin/IMaterialControl.cs
+++ b/MaterialSkin/IMaterialControl.cs
@@ -39,6 +39,6 @@
         /// <summary>
         /// Defines the OUT
         /// </summary>
-        OUT
+        OUT_
     }
 }

--- a/MaterialSkin/MaterialSkin.csproj
+++ b/MaterialSkin/MaterialSkin.csproj
@@ -137,12 +137,14 @@
     </Compile>
     <Compile Include="DrawHelper.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="Globals.cs" />
     <Compile Include="IMaterialControl.cs" />
     <Compile Include="MaterialItemCollection.cs" />
     <Compile Include="MaterialItemCollectionEditor.cs" />
     <Compile Include="MaterialSkinManager.cs" />
     <Compile Include="MouseWheelRedirector.cs" />
     <Compile Include="NativeTextRenderer.cs" />
+    <Compile Include="NativeWin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/MaterialSkin/MaterialSkinManager.cs
+++ b/MaterialSkin/MaterialSkinManager.cs
@@ -85,7 +85,7 @@
             // RemoveFontMemResourceEx
             foreach (IntPtr handle in logicalFonts.Values)
             {
-                NativeTextRenderer.DeleteObject(handle);
+                NativeWin.DeleteObject(handle);
             }
         }
 
@@ -235,7 +235,7 @@
         public Brush CheckboxOffBrush => Theme == Themes.LIGHT ? CHECKBOX_OFF_LIGHT_BRUSH : CHECKBOX_OFF_DARK_BRUSH;
         public Color CheckBoxOffDisabledColor => Theme == Themes.LIGHT ? CHECKBOX_OFF_DISABLED_LIGHT : CHECKBOX_OFF_DISABLED_DARK;
         public Brush CheckBoxOffDisabledBrush => Theme == Themes.LIGHT ? CHECKBOX_OFF_DISABLED_LIGHT_BRUSH : CHECKBOX_OFF_DISABLED_DARK_BRUSH;
-        
+
         // Switch
         public Color SwitchOffColor => Theme == Themes.LIGHT ? CHECKBOX_OFF_DARK : CHECKBOX_OFF_LIGHT; // yes, I re-use the checkbox color, sue me
         public Color SwitchOffThumbColor => Theme == Themes.LIGHT ? SWITCH_OFF_THUMB_LIGHT : SWITCH_OFF_THUMB_DARK;
@@ -319,7 +319,7 @@
 
                 case fontType.Subtitle2:
                     return new Font(RobotoFontFamilies["Roboto_Medium"], 14f, FontStyle.Bold, GraphicsUnit.Pixel);
-                
+
                 case fontType.SubtleEmphasis:
                     return new Font(RobotoFontFamilies["Roboto"], 12f, FontStyle.Italic, GraphicsUnit.Pixel);
 
@@ -378,7 +378,7 @@
             Marshal.Copy(fontdata, 0, ptrFont, dataLength);
 
             // GDI Font
-            NativeTextRenderer.AddFontMemResourceEx(fontdata, dataLength, IntPtr.Zero, out _);
+            NativeWin.AddFontMemResourceEx(fontdata, dataLength, IntPtr.Zero, out _);
 
             // GDI+ Font
             privateFontCollection.AddMemoryFont(ptrFont, dataLength);
@@ -387,12 +387,12 @@
         private IntPtr createLogicalFont(string fontName, int size, NativeTextRenderer.logFontWeight weight, byte lfItalic = 0)
         {
             // Logical font:
-            NativeTextRenderer.LogFont lfont = new NativeTextRenderer.LogFont();
+            NativeWin.LogFont lfont = new NativeWin.LogFont();
             lfont.lfFaceName = fontName;
             lfont.lfHeight = -size;
             lfont.lfWeight = (int)weight;
             lfont.lfItalic = lfItalic;
-            return NativeTextRenderer.CreateFontIndirect(lfont);
+            return NativeWin.CreateFontIndirect(lfont);
         }
 
         // Dyanmic Themes

--- a/MaterialSkin/MouseWheelRedirector.cs
+++ b/MaterialSkin/MouseWheelRedirector.cs
@@ -1,17 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualBasic;
 using System.Windows.Forms;
-using System.Runtime.InteropServices;
+
+using MaterialSkin;
 
 public class MouseWheelRedirector : IMessageFilter
 {
@@ -82,18 +72,15 @@ public class MouseWheelRedirector : IMessageFilter
             currentControl = null;
     }
 
-    private const int WM_MOUSEWHEEL = 0x20A;
     public bool PreFilterMessage(ref System.Windows.Forms.Message m)
     {
-        if (currentControl != null && m.Msg == WM_MOUSEWHEEL)
+        if (currentControl != null && m.Msg == NativeWin.WM_MOUSEWHEEL)
         {
-            SendMessage(currentControl.Handle, m.Msg, m.WParam, m.LParam);
+            NativeWin.SendMessage(currentControl.Handle, m.Msg, m.WParam, m.LParam);
             return true;
         }
         else
             return false;
     }
 
-    [DllImport("user32.dll", SetLastError = false)]
-    private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 }

--- a/MaterialSkin/NativeWin.cs
+++ b/MaterialSkin/NativeWin.cs
@@ -1,0 +1,417 @@
+﻿using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace MaterialSkin
+{
+    internal static class NativeWin
+    {
+
+        #region " CONSTS "
+
+        // Padding
+        internal const int EM_SETRECT = 0xB3;
+
+        // Cursor flickering fix
+        internal const int WM_SETCURSOR = 0x0020;
+
+        internal const int WM_MOUSEWHEEL = 0x20A;
+
+        internal const int IDC_HAND = 32649;
+
+        #endregion
+
+
+        #region " ENUMS "
+
+        /// <summary>
+        /// Window Messages
+        /// <see href="https://docs.microsoft.com/en-us/windows/win32/winmsg/about-messages-and-message-queues"/>
+        /// </summary>
+        internal enum WM
+        {
+            /// <summary>
+            /// WM_NCCALCSIZE
+            /// </summary>
+            NonClientCalcSize = 0x0083,
+            /// <summary>
+            /// WM_NCACTIVATE
+            /// </summary>
+            NonClientActivate = 0x0086,
+            /// <summary>
+            /// WM_NCLBUTTONDOWN
+            /// </summary>
+            NonClientLeftButtonDown = 0x00A1,
+            /// <summary>
+            /// WM_SYSCOMMAND
+            /// </summary>
+            SystemCommand = 0x0112,
+            /// <summary>
+            /// WM_MOUSEMOVE
+            /// </summary>
+            MouseMove = 0x0200,
+            /// <summary>
+            /// WM_LBUTTONDOWN
+            /// </summary>
+            LeftButtonDown = 0x0201,
+            /// <summary>
+            /// WM_LBUTTONUP
+            /// </summary>
+            LeftButtonUp = 0x0202,
+            /// <summary>
+            /// WM_LBUTTONDBLCLK
+            /// </summary>
+            LeftButtonDoubleClick = 0x0203,
+            /// <summary>
+            /// WM_RBUTTONDOWN
+            /// </summary>
+            RightButtonDown = 0x0204,
+        }
+
+
+        /// <summary>
+        /// Hit Test Results
+        /// <see href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-nchittest"/>
+        /// </summary>
+        internal enum HT
+        {
+            /// <summary>
+            /// HTNOWHERE - Nothing under cursor
+            /// </summary>
+            None = 0,
+            /// <summary>
+            /// HTCAPTION - Titlebar
+            /// </summary>
+            Caption = 2,
+            /// <summary>
+            /// HTLEFT - Left border
+            /// </summary>
+            Left = 10,
+            /// <summary>
+            /// HTRIGHT - Right border
+            /// </summary>
+            Right = 11,
+            /// <summary>
+            /// HTTOP - Top border
+            /// </summary>
+            Top = 12,
+            /// <summary>
+            /// HTTOPLEFT - Top left corner
+            /// </summary>
+            TopLeft = 13,
+            /// <summary>
+            /// HTTOPRIGHT - Top right corner
+            /// </summary>
+            TopRight = 14,
+            /// <summary>
+            /// HTBOTTOM - Bottom border
+            /// </summary>
+            Bottom = 15,
+            /// <summary>
+            /// HTBOTTOMLEFT - Bottom left corner
+            /// </summary>
+            BottomLeft = 16,
+            /// <summary>
+            /// HTBOTTOMRIGHT - Bottom right corner
+            /// </summary>
+            BottomRight = 17,
+        }
+
+        /// <summary>
+        /// Window Styles
+        /// <see href="https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles"/>
+        /// </summary>
+        internal enum WS
+        {
+            /// <summary>
+            /// WS_MINIMIZEBOX - Allow minimizing from taskbar
+            /// </summary>
+            MinimizeBox = 0x20000,
+            /// <summary>
+            /// WS_SIZEFRAME - Required for Aero Snapping
+            /// </summary>
+            SizeFrame = 0x40000,
+            /// <summary>
+            /// WS_SYSMENU - Trigger the creation of the system menu
+            /// </summary>
+            SysMenu = 0x80000,
+        }
+
+
+
+        /// <summary>
+        /// Track Popup Menu Flags
+        /// <see href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-trackpopupmenu"/>
+        /// </summary>
+        internal enum TPM
+        {
+            /// <summary>
+            /// TPM_LEFTALIGN
+            /// </summary>
+            LeftAlign = 0x0000,
+            /// <summary>
+            /// TPM_RETURNCMD
+            /// </summary>
+            ReturnCommand = 0x0100,
+        }
+
+        #endregion
+
+
+        #region " STRUCTS "
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct RECT
+        {
+            public readonly int Left;
+            public readonly int Top;
+            public readonly int Right;
+            public readonly int Bottom;
+
+            private RECT(int left, int top, int right, int bottom)
+            {
+                Left = left;
+                Top = top;
+                Right = right;
+                Bottom = bottom;
+            }
+
+            internal RECT(Rectangle r) : this(r.Left, r.Top, r.Right, r.Bottom)
+            {
+            }
+
+            internal int Height
+            {
+                get
+                {
+                    return Bottom - Top;
+                }
+            }
+        }
+
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        internal class LogFont
+        {
+            public int lfHeight = 0;
+            public int lfWidth = 0;
+            public int lfEscapement = 0;
+            public int lfOrientation = 0;
+            public int lfWeight = 0;
+            public byte lfItalic = 0;
+            public byte lfUnderline = 0;
+            public byte lfStrikeOut = 0;
+            public byte lfCharSet = 0;
+            public byte lfOutPrecision = 0;
+            public byte lfClipPrecision = 0;
+            public byte lfQuality = 0;
+            public byte lfPitchAndFamily = 0;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string lfFaceName = string.Empty;
+        }
+
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BlendFunction
+        {
+            public byte BlendOp;
+            public byte BlendFlags;
+            public byte SourceConstantAlpha;
+            public byte AlphaFormat;
+
+            internal BlendFunction(byte alpha)
+            {
+                BlendOp = 0;
+                BlendFlags = 0;
+                AlphaFormat = 0;
+                SourceConstantAlpha = alpha;
+            }
+        }
+
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct BitMapInfo
+        {
+            public int biSize;
+            public int biWidth;
+            public int biHeight;
+            public short biPlanes;
+            public short biBitCount;
+            public int biCompression;
+            public int biSizeImage;
+            public int biXPelsPerMeter;
+            public int biYPelsPerMeter;
+            public int biClrUsed;
+            public int biClrImportant;
+            public byte bmiColors_rgbBlue;
+            public byte bmiColors_rgbGreen;
+            public byte bmiColors_rgbRed;
+            public byte bmiColors_rgbReserved;
+        }
+
+        #endregion
+
+
+        #region Low Level Windows Methods
+
+        #region " USER32.DLL "
+
+        private const string USER32_DLL = "user32.dll";
+
+        /// <summary>
+        ///     Provides a single method to call either the 32-bit or 64-bit method based on the size of an <see cref="IntPtr"/> for getting the
+        ///     Window Style flags.<br/>
+        ///     <see href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlongptra">GetWindowLongPtr</see>
+        /// </summary>
+        internal static IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)
+        {
+            if (IntPtr.Size == 8)
+                return GetWindowLongPtr64(hWnd, nIndex);
+            else
+                return GetWindowLong(hWnd, nIndex);
+        }
+
+        /// <summary>
+        ///     Provides a single method to call either the 32-bit or 64-bit method based on the size of an <see cref="IntPtr"/> for setting the
+        ///     Window Style flags.<br/>
+        ///     <see href="https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptra">SetWindowLongPtr</see>
+        /// </summary>
+        internal static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+        {
+            if (IntPtr.Size == 8)
+                return SetWindowLongPtr64(hWnd, nIndex, dwNewLong);
+            else
+                return SetWindowLong(hWnd, nIndex, dwNewLong.ToInt32());
+        }
+
+        [DllImport(USER32_DLL, EntryPoint = "GetWindowLong")]
+        internal static extern IntPtr GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport(USER32_DLL, EntryPoint = "GetWindowLongPtr")]
+        internal static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+        [DllImport(USER32_DLL, EntryPoint = "SetWindowLong")]
+        internal static extern IntPtr SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport(USER32_DLL, EntryPoint = "SetWindowLongPtr")]
+        internal static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+
+        [DllImport(USER32_DLL, CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern IntPtr LoadCursor(IntPtr hInstance, int lpCursorName);
+
+        [DllImport(USER32_DLL, CharSet = CharSet.Auto)]
+        internal static extern IntPtr SetCursor(IntPtr hCursor);
+
+        
+        #region " USER32.DLL - SendMessage overloads"
+
+        [DllImport(USER32_DLL)]
+        internal static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
+
+        [DllImport(USER32_DLL, CharSet = CharSet.Auto)]
+        internal static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
+
+        [DllImport(USER32_DLL)]
+        internal static extern IntPtr SendMessage(IntPtr hWnd, Int32 wMsg, Int32 wParam, ref Point lParam);
+
+        [DllImport(USER32_DLL, EntryPoint = "SendMessage", CharSet = CharSet.Auto)]
+        internal static extern int SendMessageRefRect(IntPtr hWnd, uint msg, int wParam, ref RECT rect);
+
+        [DllImport(USER32_DLL, SetLastError = false)]
+        internal static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport(USER32_DLL, CharSet = CharSet.Auto)]
+        internal static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+        #endregion " USER32.DLL - SendMessage overloads"
+
+
+        [DllImport(USER32_DLL)]
+        internal static extern bool ReleaseCapture();
+
+        [DllImport(USER32_DLL)]
+        internal static extern int TrackPopupMenuEx(IntPtr hmenu, uint fuFlags, int x, int y, IntPtr hwnd, IntPtr lptpm);
+
+        [DllImport(USER32_DLL)]
+        internal static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+
+        [DllImport(USER32_DLL, CharSet = CharSet.Auto)]
+        internal static extern int DrawText(IntPtr hdc, string lpchText, int cchText, ref RECT lprc, NativeTextRenderer.TextFormatFlags dwDTFormat);
+
+        [DllImport(USER32_DLL, EntryPoint = "DrawTextW")]
+        internal static extern int DrawText(IntPtr hdc, [MarshalAs(UnmanagedType.LPWStr)] string str, int len, ref RECT rect, uint uFormat);
+
+        #endregion " USER32.DLL "
+
+
+        #region " GDI32.DLL "
+
+        private const string GDI32_DLL = "gdi32.dll";
+
+        [DllImport(GDI32_DLL, EntryPoint = "CreateRoundRectRgn")]
+        internal static extern IntPtr CreateRoundRectRgn(
+                int nLeftRect,     // x-coordinate of upper-left corner
+                int nTopRect,      // y-coordinate of upper-left corner
+                int nRightRect,    // x-coordinate of lower-right corner
+                int nBottomRect,   // y-coordinate of lower-right corner
+                int nWidthEllipse, // width of ellipse
+                int nHeightEllipse // height of ellipse
+                );
+
+        [DllImport(GDI32_DLL)]
+        internal static extern int SetBkMode(IntPtr hdc, int mode);
+
+        [DllImport(GDI32_DLL)]
+        internal static extern IntPtr SelectObject(IntPtr hdc, IntPtr hgdiObj);
+
+        [DllImport(GDI32_DLL)]
+        internal static extern int SetTextColor(IntPtr hdc, int color);
+
+        [DllImport(GDI32_DLL, EntryPoint = "GetTextExtentPoint32W")]
+        internal static extern int GetTextExtentPoint32(IntPtr hdc, [MarshalAs(UnmanagedType.LPWStr)] string str, int len, ref Size size);
+
+        [DllImport(GDI32_DLL, EntryPoint = "GetTextExtentExPointW")]
+        internal static extern bool GetTextExtentExPoint(IntPtr hDc, [MarshalAs(UnmanagedType.LPWStr)] string str, int nLength, int nMaxExtent, int[] lpnFit, int[] alpDx, ref Size size);
+
+        [DllImport(GDI32_DLL, EntryPoint = "TextOutW")]
+        internal static extern bool TextOut(IntPtr hdc, int x, int y, [MarshalAs(UnmanagedType.LPWStr)] string str, int len);
+
+        [DllImport(GDI32_DLL)]
+        internal static extern int SetTextAlign(IntPtr hdc, uint fMode);
+
+        [DllImport(GDI32_DLL)]
+        internal static extern int SelectClipRgn(IntPtr hdc, IntPtr hrgn);
+
+        [DllImport(GDI32_DLL)]
+        internal static extern bool DeleteObject(IntPtr hObject);
+
+        [DllImport(GDI32_DLL, ExactSpelling = true, SetLastError = true)]
+        internal static extern bool DeleteDC(IntPtr hdc);
+
+        [DllImport(GDI32_DLL, CharSet = CharSet.Auto)]
+        internal static extern IntPtr CreateFontIndirect([In, MarshalAs(UnmanagedType.LPStruct)] LogFont lplf);
+
+        [DllImport(GDI32_DLL, ExactSpelling = true)]
+        internal static extern IntPtr AddFontMemResourceEx(byte[] pbFont, int cbFont, IntPtr pdv, out uint pcFonts);
+
+        [DllImport(GDI32_DLL)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool BitBlt(IntPtr hdc, int nXDest, int nYDest, int nWidth, int nHeight, IntPtr hdcSrc, int nXSrc, int nYSrc, uint dwRop);
+
+        [DllImport(GDI32_DLL, EntryPoint = "GdiAlphaBlend")]
+        internal static extern bool AlphaBlend(IntPtr hdcDest, int nXOriginDest, int nYOriginDest, int nWidthDest, int nHeightDest, IntPtr hdcSrc, int nXOriginSrc, int nYOriginSrc, int nWidthSrc, int nHeightSrc, BlendFunction blendFunction);
+
+        [DllImport(GDI32_DLL, ExactSpelling = true, SetLastError = true)]
+        internal static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+        [DllImport(GDI32_DLL)]
+        internal static extern IntPtr CreateDIBSection(IntPtr hdc, [In] ref BitMapInfo pbmi, uint iUsage, out IntPtr ppvBits, IntPtr hSection, uint dwOffset);
+
+        #endregion " GDI32.DLL "
+
+        #endregion
+    }
+}

--- a/MaterialSkin/Properties/AssemblyInfo.cs
+++ b/MaterialSkin/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MaterialSkin")]
-[assembly: AssemblyCopyright("Copyright Leonardo C Bottaro © 2021")]
+[assembly: AssemblyCopyright("Copyright Leonardo C Bottaro © 2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.1.0")]
-[assembly: AssemblyFileVersion("2.3.1.0")]
+[assembly: AssemblyVersion("2.3.1.3")]
+[assembly: AssemblyFileVersion("2.3.1.3")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/MaterialSkinExample/MainForm.Designer.cs
+++ b/MaterialSkinExample/MainForm.Designer.cs
@@ -1183,7 +1183,7 @@ namespace MaterialSkinExample
             "hi"});
             this.materialComboBox6.Location = new System.Drawing.Point(463, 407);
             this.materialComboBox6.MaxDropDownItems = 4;
-            this.materialComboBox6.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialComboBox6.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialComboBox6.Name = "materialComboBox6";
             this.materialComboBox6.Size = new System.Drawing.Size(190, 49);
             this.materialComboBox6.StartIndex = 0;
@@ -1209,7 +1209,7 @@ namespace MaterialSkinExample
             "Hello There, I hope you\'ll have a wonderfull day"});
             this.materialComboBox2.Location = new System.Drawing.Point(463, 462);
             this.materialComboBox2.MaxDropDownItems = 4;
-            this.materialComboBox2.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialComboBox2.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialComboBox2.Name = "materialComboBox2";
             this.materialComboBox2.Size = new System.Drawing.Size(435, 49);
             this.materialComboBox2.StartIndex = 0;
@@ -1303,7 +1303,7 @@ namespace MaterialSkinExample
             "down!"});
             this.materialComboBox5.Location = new System.Drawing.Point(463, 352);
             this.materialComboBox5.MaxDropDownItems = 4;
-            this.materialComboBox5.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialComboBox5.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialComboBox5.Name = "materialComboBox5";
             this.materialComboBox5.Size = new System.Drawing.Size(190, 49);
             this.materialComboBox5.StartIndex = 0;
@@ -1398,7 +1398,7 @@ namespace MaterialSkinExample
             "down!"});
             this.materialComboBox4.Location = new System.Drawing.Point(258, 407);
             this.materialComboBox4.MaxDropDownItems = 4;
-            this.materialComboBox4.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialComboBox4.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialComboBox4.Name = "materialComboBox4";
             this.materialComboBox4.Size = new System.Drawing.Size(190, 49);
             this.materialComboBox4.StartIndex = 0;
@@ -1490,7 +1490,7 @@ namespace MaterialSkinExample
             "Long item that won\'t fit here"});
             this.materialComboBox1.Location = new System.Drawing.Point(258, 352);
             this.materialComboBox1.MaxDropDownItems = 4;
-            this.materialComboBox1.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialComboBox1.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialComboBox1.Name = "materialComboBox1";
             this.materialComboBox1.Size = new System.Drawing.Size(190, 49);
             this.materialComboBox1.StartIndex = 0;
@@ -1796,7 +1796,7 @@ namespace MaterialSkinExample
             this.materialMaskedTextBox1.Location = new System.Drawing.Point(528, 437);
             this.materialMaskedTextBox1.Mask = "+00-0-00-00-00-00";
             this.materialMaskedTextBox1.MaxLength = 32767;
-            this.materialMaskedTextBox1.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialMaskedTextBox1.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialMaskedTextBox1.Name = "materialMaskedTextBox1";
             this.materialMaskedTextBox1.PasswordChar = '\0';
             this.materialMaskedTextBox1.PrefixSuffixText = null;
@@ -1908,7 +1908,7 @@ namespace MaterialSkinExample
             "Suffix"});
             this.materialComboBox7.Location = new System.Drawing.Point(729, 182);
             this.materialComboBox7.MaxDropDownItems = 4;
-            this.materialComboBox7.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialComboBox7.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialComboBox7.Name = "materialComboBox7";
             this.materialComboBox7.Size = new System.Drawing.Size(183, 49);
             this.materialComboBox7.StartIndex = 0;
@@ -1980,7 +1980,7 @@ namespace MaterialSkinExample
             this.materialTextBox21.LeadingIcon = null;
             this.materialTextBox21.Location = new System.Drawing.Point(528, 114);
             this.materialTextBox21.MaxLength = 32767;
-            this.materialTextBox21.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialTextBox21.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialTextBox21.Name = "materialTextBox21";
             this.materialTextBox21.PasswordChar = '\0';
             this.materialTextBox21.PrefixSuffixText = "$";
@@ -2012,7 +2012,7 @@ namespace MaterialSkinExample
             this.materialMultiLineTextBox21.Hint = "MaterialMultiLineTextBox2";
             this.materialMultiLineTextBox21.Location = new System.Drawing.Point(25, 385);
             this.materialMultiLineTextBox21.MaxLength = 2147483647;
-            this.materialMultiLineTextBox21.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialMultiLineTextBox21.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialMultiLineTextBox21.Name = "materialMultiLineTextBox21";
             this.materialMultiLineTextBox21.PasswordChar = '\0';
             this.materialMultiLineTextBox21.ReadOnly = false;
@@ -2039,7 +2039,7 @@ namespace MaterialSkinExample
             this.materialTextBox5.LeadingIcon = null;
             this.materialTextBox5.Location = new System.Drawing.Point(222, 170);
             this.materialTextBox5.MaxLength = 50;
-            this.materialTextBox5.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialTextBox5.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialTextBox5.Name = "materialTextBox5";
             this.materialTextBox5.Size = new System.Drawing.Size(209, 50);
             this.materialTextBox5.TabIndex = 69;
@@ -2058,7 +2058,7 @@ namespace MaterialSkinExample
             this.materialTextBox4.LeadingIcon = null;
             this.materialTextBox4.Location = new System.Drawing.Point(25, 170);
             this.materialTextBox4.MaxLength = 50;
-            this.materialTextBox4.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialTextBox4.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialTextBox4.Name = "materialTextBox4";
             this.materialTextBox4.Size = new System.Drawing.Size(191, 50);
             this.materialTextBox4.TabIndex = 68;
@@ -2076,7 +2076,7 @@ namespace MaterialSkinExample
             this.materialTextBox3.LeadingIcon = null;
             this.materialTextBox3.Location = new System.Drawing.Point(25, 338);
             this.materialTextBox3.MaxLength = 50;
-            this.materialTextBox3.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialTextBox3.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialTextBox3.Name = "materialTextBox3";
             this.materialTextBox3.Size = new System.Drawing.Size(406, 36);
             this.materialTextBox3.TabIndex = 67;
@@ -2134,7 +2134,7 @@ namespace MaterialSkinExample
             this.materialTextBox2.LeadingIcon = global::MaterialSkinExample.Properties.Resources.baseline_fingerprint_black_24dp;
             this.materialTextBox2.Location = new System.Drawing.Point(25, 282);
             this.materialTextBox2.MaxLength = 50;
-            this.materialTextBox2.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialTextBox2.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialTextBox2.Name = "materialTextBox2";
             this.materialTextBox2.UseSystemPasswordChar = true;
             this.materialTextBox2.Size = new System.Drawing.Size(406, 50);
@@ -2153,7 +2153,7 @@ namespace MaterialSkinExample
             this.materialTextBox1.LeadingIcon = null;
             this.materialTextBox1.Location = new System.Drawing.Point(25, 114);
             this.materialTextBox1.MaxLength = 50;
-            this.materialTextBox1.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialTextBox1.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialTextBox1.Name = "materialTextBox1";
             this.materialTextBox1.Size = new System.Drawing.Size(406, 50);
             this.materialTextBox1.TabIndex = 1;
@@ -2171,7 +2171,7 @@ namespace MaterialSkinExample
             this.materialSingleLineTextField2.LeadingIcon = null;
             this.materialSingleLineTextField2.Location = new System.Drawing.Point(25, 226);
             this.materialSingleLineTextField2.MaxLength = 50;
-            this.materialSingleLineTextField2.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialSingleLineTextField2.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialSingleLineTextField2.Name = "materialSingleLineTextField2";
             this.materialSingleLineTextField2.Size = new System.Drawing.Size(406, 50);
             this.materialSingleLineTextField2.TabIndex = 2;
@@ -2236,7 +2236,7 @@ namespace MaterialSkinExample
             this.materialListView1.Location = new System.Drawing.Point(25, 149);
             this.materialListView1.MinimumSize = new System.Drawing.Size(200, 100);
             this.materialListView1.MouseLocation = new System.Drawing.Point(-1, -1);
-            this.materialListView1.MouseState = MaterialSkin.MouseState.OUT;
+            this.materialListView1.MouseState = MaterialSkin.MouseState.OUT_;
             this.materialListView1.Name = "materialListView1";
             this.materialListView1.OwnerDraw = true;
             this.materialListView1.Scrollable = false;

--- a/MaterialSkinExample/Properties/AssemblyInfo.cs
+++ b/MaterialSkinExample/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MaterialSkinExample")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.3.1.3")]
+[assembly: AssemblyFileVersion("2.3.1.3")]


### PR DESCRIPTION
  - Code Cleansing & Refactoring:
    - moved all p/invoke declarations to a new static class "NativeWin" (NativeWin.cs)
      - there were a significant number of duplicated declarations on several controls
      - affected files:
        - NativeTextRenderer.cs
        - MouseWheelRedirector.cs
        - MaterialDialog.cs
        - MaterialForm.cs
        - MaterialMultiLineTextBox.cs
        - MaterialMultiLineTextBox2.cs
        - MaterialScrollBar.cs
        - MaterialSnackBar.cs
        - MaterialTextBox.cs
        - MaterialSkinManager.cs

    - moved several const declarations related to native Window Message IDs to new static class "NativeWin"
      - affected files:
        - MouseWheelRedirector.cs

    - moved all possible category's labels to a new static class "CategoryLabels" (Globals.cs) and replaced the Category Labels by the corresponding const string
      - affected files:
        - MaterialButton.cs
        - MaterialCheckBox.cs
        - MaterialComboBox.cs
        - MaterialDrawer.cs
        - MaterialExpansionPanel.cs
        - MaterialFloatingActionButton.cs
        - MaterialForm.cs
        - MaterialLabel.cs
        - MaterialListBox.cs
        - MaterialListView.cs
        - MaterialMaskedTextBox.cs
        - MaterialMultiLineTextBox.cs
        - MaterialMultiLineTextBox2.cs
        - MaterialRadioButton.cs
        - MaterialScrollBar.cs
        - MaterialSlider.cs
        - MaterialSnackBar.cs
        - MaterialSwitch.cs
        - MaterialTabSelector.cs
        - MaterialTextBox.cs
        - MaterialTextBox2.cs

    - moved several const declarations and enum declarations that were shared among files to a new file Globals.cs
        - MaterialDrawer.cs

  - Enhancement - compatibility with Msft CLI/C++:
    - enum value MouseState.OUT (IMaterialControl.cs) renamed to MouseState.OUT_
      - "OUT" keyword is a reserved word on CLI/C++.