### PR TITLE
Fixed MaterialComboBox SelectedIndexChanged not refreshing and improvement.

### DIFF
--- a/MaterialSkin/Controls/MaterialComboBox.cs
+++ b/MaterialSkin/Controls/MaterialComboBox.cs
@@ -147,6 +147,18 @@
                 MouseState = MouseState.OUT;
                 Invalidate();
             };
+            SelectedIndexChanged += (sender, args) =>
+            {
+                Invalidate();
+            };
+            KeyUp += (sender, args) =>
+            { 
+                if (Enabled && DropDownStyle == ComboBoxStyle.DropDownList && (args.KeyCode == Keys.Delete || args.KeyCode == Keys.Back))
+                {
+                    SelectedIndex = -1;
+                    Invalidate();
+                }
+            };
         }
 
         protected override void OnPaint(PaintEventArgs pevent)


### PR DESCRIPTION
Fixed MaterialComboBox SelectedIndexChanged not refreshing and a little improvement for an enabled DropDownList ComboBox, when hit Delete key or Backspace key the selected index will become -1.

This PR will fix #341 .