### PR TITLE
Removed 4.5 Target Framework from Core project

### DIFF
--- a/MaterialSkin/MaterialSkinCore.csproj
+++ b/MaterialSkin/MaterialSkinCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-		<TargetFrameworks>net5.0-windows;net48;net461;net45</TargetFrameworks>
+		<TargetFrameworks>net5.0-windows;net48;net461</TargetFrameworks>
 		<RuntimeIdentifier>win</RuntimeIdentifier>
       <OutputType>Library</OutputType>
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
Removed 4.5 Target Framework from Core project as long as this version is not anymore supported.