### PR TITLE
Issue on MaterialComboBox StartIndex property's set.

### DIFF
--- a/MaterialSkin/Controls/MaterialComboBox.cs
+++ b/MaterialSkin/Controls/MaterialComboBox.cs
@@ -74,7 +74,10 @@
                 _startIndex = value;
                 try
                 {
-                    base.SelectedIndex = value;
+                    if (base.Items.Count > 0)
+                    {
+                        base.SelectedIndex = value;
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
When Combobox has no Items and StartIndex is set to 0 an `ArgumentOutOfRangeException` is raised. Solved by checking the `Items.Count` on property's set.